### PR TITLE
feat: Use base64 string for the `relay` input payload instead of an array of numbers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,53 +1,46 @@
-mod rpc_conf;
-mod signing;
-
-#[cfg(test)]
-use axum::Json;
-use axum::{extract, http::StatusCode, response::IntoResponse, Router, routing::post};
+use axum::{http::StatusCode, response::IntoResponse, routing::post, Json, Router};
 use config::{Config, File};
+use once_cell::sync::Lazy;
+use rpc_conf::rpc_transaction_error;
+use serde_json::json;
+use std::net::SocketAddr;
+use tower_http::trace::TraceLayer;
+use tracing::{debug, info};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
 #[cfg(test)]
 use near_crypto::Signature;
 use near_crypto::{KeyType, PublicKey};
 use near_jsonrpc_client::methods::broadcast_tx_commit::RpcBroadcastTxCommitRequest;
-#[cfg(test)]
-use near_primitives::borsh::BorshSerialize;
-use near_primitives::borsh::BorshDeserialize;
+use near_primitives::delegate_action::SignedDelegateAction;
 #[cfg(test)]
 use near_primitives::delegate_action::{DelegateAction, NonDelegateAction};
-use near_primitives::delegate_action::SignedDelegateAction;
 use near_primitives::hash::CryptoHash;
 #[cfg(test)]
 use near_primitives::transaction::TransferAction;
 use near_primitives::transaction::{Action, Transaction};
+use near_primitives::types::AccountId;
 #[cfg(test)]
 use near_primitives::types::{BlockHeight, Nonce};
-use once_cell::sync::Lazy;
-use serde_json::json;
-use std::net::SocketAddr;
-use near_primitives::types::AccountId;
-use tower_http::trace::TraceLayer;
-use tracing::{debug, info};
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
-use rpc_conf::rpc_transaction_error;
-use signing::sign_transaction;
-use crate::rpc_conf::{NetworkConfig, RPCConfig};
 
+mod rpc_conf;
+mod schemas;
+mod signing;
 
 // load config from toml and setup json rpc client
 static LOCAL_CONF: Lazy<Config> = Lazy::new(|| {
-    let conf: Config = Config::builder()
+    Config::builder()
         .add_source(File::with_name("config.toml"))
         .build()
-        .unwrap();
-    conf
+        .unwrap()
 });
 static JSON_RPC_CLIENT: Lazy<near_jsonrpc_client::JsonRpcClient> = Lazy::new(|| {
     let network_name: String = LOCAL_CONF.get("network").unwrap();
-    let rpc_config = RPCConfig::default();
+    let rpc_config = crate::rpc_conf::RPCConfig::default();
 
     // optional overrides
     if LOCAL_CONF.get::<bool>("override_rpc_conf").unwrap() {
-        let network_config = NetworkConfig {
+        let network_config = crate::rpc_conf::NetworkConfig {
             network_name,
             rpc_url: LOCAL_CONF.get("rpc_url").unwrap(),
             rpc_api_key: LOCAL_CONF.get("rpc_api_key").unwrap(),
@@ -59,29 +52,19 @@ static JSON_RPC_CLIENT: Lazy<near_jsonrpc_client::JsonRpcClient> = Lazy::new(|| 
         let network_config = rpc_config.networks.get(&network_name).unwrap();
         network_config.json_rpc_client()
     }
-
 });
-static IP_ADDRESS: Lazy<[u8; 4]> = Lazy::new(|| {
-    let ip_address: [u8; 4] = LOCAL_CONF.get("ip_address").unwrap();
-    ip_address
-});
-static PORT: Lazy<u16> = Lazy::new(|| {
-    let port: u16 = LOCAL_CONF.get("port").unwrap();
-    port
-});
-static RELAYER_ACCOUNT_ID: Lazy<String> = Lazy::new(|| {
-    let relayer_account_id: String = LOCAL_CONF.get("relayer_account_id").unwrap();
-    relayer_account_id
-});
-static KEYS_FILENAME: Lazy<String> = Lazy::new(|| {
-    let keys_filename: String = LOCAL_CONF.get("keys_filename").unwrap();
-    keys_filename
-});
+static IP_ADDRESS: Lazy<[u8; 4]> = Lazy::new(|| LOCAL_CONF.get("ip_address").unwrap());
+static PORT: Lazy<u16> = Lazy::new(|| LOCAL_CONF.get("port").unwrap());
+static RELAYER_ACCOUNT_ID: Lazy<AccountId> =
+    Lazy::new(|| LOCAL_CONF.get("relayer_account_id").unwrap());
+static KEYS_FILENAME: Lazy<String> = Lazy::new(|| LOCAL_CONF.get("keys_filename").unwrap());
 
 #[tokio::main]
 async fn main() {
     // initialize tracing (aka logging)
-    tracing_subscriber::registry().with(tracing_subscriber::fmt::layer()).init();
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer())
+        .init();
 
     // build our application with a route
     let app = Router::new()
@@ -93,110 +76,84 @@ async fn main() {
     // run our app with hyper
     // `axum::Server` is a re-export of `hyper::Server`
     let addr = SocketAddr::from((*IP_ADDRESS, *PORT));
-    info!("listening on {}", addr);
+    info!("listening on {addr}");
     axum::Server::bind(&addr)
         .serve(app.into_make_service())
         .await
         .unwrap();
 }
 
-async fn relay(
-    data: extract::Json<Vec<u8>>,
-) -> impl IntoResponse {
-    // deserialize SignedDelegateAction using borsh
-    match SignedDelegateAction::try_from_slice(&data.0) {
-        Ok(signed_delegate_action) => {
-            debug!("Deserialized SignedDelegateAction object: {:#?}", signed_delegate_action);
+async fn relay(Json(data): Json<crate::schemas::RelayInputArgs>) -> impl IntoResponse {
+    let signed_delegate_action: SignedDelegateAction = data.signed_delegate_action.into();
+    debug!("Deserialized SignedDelegateAction object: {signed_delegate_action:#?}");
 
-            // create Transaction from SignedDelegateAction
-            let signer_account_id: AccountId = RELAYER_ACCOUNT_ID.as_str().parse().unwrap();
-            // the receiver of the txn is the sender of the signed delegate action
-            let receiver_id = signed_delegate_action.delegate_action.sender_id.clone();
-            // TODO for batching add multiple signed delegate actions, then flush
-            let actions = vec![Action::Delegate(signed_delegate_action)];
-            let unsigned_transaction = Transaction{
-                signer_id: signer_account_id.clone(),
-                public_key: PublicKey::empty(KeyType::ED25519),  // gets replaced when signing txn
-                nonce: 0,  // gets replaced when signing txn
-                receiver_id,
-                block_hash: CryptoHash::default(),  // gets replaced when signing txn
-                actions,
+    let unsigned_transaction = Transaction {
+        // create Transaction from SignedDelegateAction
+        signer_id: RELAYER_ACCOUNT_ID.clone(),
+        // the receiver of the txn is the sender of the signed delegate action
+        receiver_id: signed_delegate_action.delegate_action.sender_id.clone(),
+        // gets replaced when signing txn
+        public_key: PublicKey::empty(KeyType::ED25519),
+        // gets replaced when signing txn
+        nonce: 0,
+        // gets replaced when signing txn
+        block_hash: CryptoHash::default(),
+        // TODO for batching add multiple signed delegate actions, then flush
+        actions: vec![Action::Delegate(signed_delegate_action)],
+    };
+    debug!("unsigned_transaction {unsigned_transaction:?}");
+
+    // sign transaction with locally stored key from json file
+    let signed_transaction_result =
+        crate::signing::sign_transaction(unsigned_transaction, &KEYS_FILENAME, &JSON_RPC_CLIENT)
+            .await;
+    match signed_transaction_result {
+        Ok(signed_transaction) => {
+            // send the SignedTransaction with retry logic
+            info!("Sending transaction ...");
+            let mut sleep_time_ms = 100;
+            let transaction_info = loop {
+                let transaction_info_result = JSON_RPC_CLIENT
+                    .call(RpcBroadcastTxCommitRequest {
+                        signed_transaction: signed_transaction.clone(),
+                    })
+                    .await;
+                match transaction_info_result {
+                    Ok(response) => {
+                        break response;
+                    }
+                    Err(err) => match rpc_transaction_error(err) {
+                        Ok(_) => {
+                            tokio::time::sleep(std::time::Duration::from_millis(sleep_time_ms))
+                                .await;
+                            sleep_time_ms *= 2; // exponential backoff
+                        }
+                        Err(report) => {
+                            let err_msg = format!("Error sending transaction to RPC: {report}");
+                            info!("{err_msg}");
+                            return (StatusCode::INTERNAL_SERVER_ERROR, err_msg).into_response();
+                        }
+                    },
+                };
             };
-            debug!("unsigned_transaction {:?}", unsigned_transaction);
 
-            // sign transaction with locally stored key from json file
-            let signed_transaction_result = sign_transaction(
-                unsigned_transaction,
-                KEYS_FILENAME.as_str(),
-                JSON_RPC_CLIENT.clone(),
-            ).await;
-            match signed_transaction_result {
-                Ok(_) => {
-                    let signed_transaction = signed_transaction_result.unwrap().unwrap();
-
-                    // send the SignedTransaction with retry logic
-                    info!("Sending transaction ...");
-                    let mut sleep_time_ms = 100;
-                    let transaction_info = loop {
-                        let transaction_info_result = JSON_RPC_CLIENT
-                            .call(RpcBroadcastTxCommitRequest{signed_transaction: signed_transaction.clone()})
-                            .await;
-                        match transaction_info_result {
-                            Ok(response) => {
-                                break response;
-                            }
-                            Err(err) => match rpc_transaction_error(err) {
-                                Ok(_) => {
-                                    tokio::time::sleep(std::time::Duration::from_millis(sleep_time_ms)).await;
-                                    sleep_time_ms *= 2;  // exponential backoff
-                                }
-                                Err(report) => {
-                                    let err_msg = format!(
-                                        "{}: {:?}",
-                                        "Error sending transaction to RPC",
-                                        report.to_string()
-                                    );
-                                    info!("{}", err_msg);
-                                    return (
-                                        StatusCode::INTERNAL_SERVER_ERROR,
-                                        err_msg,
-                                    ).into_response()
-                                },
-                            },
-                        };
-                    };
-
-                    // build response json
-                    let success_msg_json = json!({
-                                "message": "Successfully relayed and sent transaction.",
-                                "status": transaction_info.status,
-                                "Transaction Outcome Logs": transaction_info.transaction_outcome.outcome.logs.join("\n"),
-                            });
-                    info!("Success message: {:?}", success_msg_json);
-                    let success_msg_str = serde_json::to_string(&success_msg_json).unwrap();
-                    success_msg_str.into_response()
-                }
-                Err(_) => {
-                    let err_msg = String::from("Error signing transaction");
-                    info!("{}", err_msg);
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        err_msg,
-                    ).into_response()
-                }
-            }
-        },
-        Err(e) => {
-            let err_msg = format!("{}: {:?}",
-                "Error deserializing payload data object",
-                e.to_string(),
-            );
-            info!("{}", err_msg);
-            (
-                StatusCode::BAD_REQUEST,
-                err_msg,
-            ).into_response()
-        },
+            // build response json
+            let success_msg_json = json!({
+                "message": "Successfully relayed and sent transaction.",
+                "status": transaction_info.status,
+                "transaction_hash": transaction_info.transaction.hash,
+                "transaction_outcome_logs": transaction_info.transaction_outcome.outcome.logs.join("\n"),
+            });
+            info!("Success message: {success_msg_json:?}");
+            serde_json::to_string(&success_msg_json)
+                .unwrap()
+                .into_response()
+        }
+        Err(_) => {
+            let err_msg = String::from("Error signing transaction");
+            info!("{err_msg}");
+            (StatusCode::INTERNAL_SERVER_ERROR, err_msg).into_response()
+        }
     }
 }
 
@@ -205,91 +162,66 @@ async fn relay(
 */
 #[cfg(test)]
 fn create_signed_delegate_action(
-    sender_id: String,
-    receiver_id: String,
+    sender_id: near_primitives::types::AccountId,
+    receiver_id: near_primitives::types::AccountId,
     actions: Vec<Action>,
-    nonce: i32,
-    max_block_height: i32
+    nonce: Nonce,
+    max_block_height: BlockHeight,
 ) -> SignedDelegateAction {
-    let max_block_height: i32 = max_block_height;
-    let public_key: PublicKey = PublicKey::empty(KeyType::ED25519);
-    let signature: Signature = Signature::empty(KeyType::ED25519);
     SignedDelegateAction {
         delegate_action: DelegateAction {
-            sender_id: sender_id.parse().unwrap(),
-            receiver_id: receiver_id.parse().unwrap(),
+            sender_id,
+            receiver_id,
             actions: actions
-                .iter()
-                .map(|a| NonDelegateAction::try_from(a.clone()).unwrap())
+                .into_iter()
+                .map(|a| NonDelegateAction::try_from(a).unwrap())
                 .collect(),
-            nonce: nonce as Nonce,
-            max_block_height: max_block_height as BlockHeight,
-            public_key,
+            nonce,
+            max_block_height,
+            public_key: PublicKey::empty(KeyType::ED25519),
         },
-        signature,
+        signature: Signature::empty(KeyType::ED25519),
     }
 }
 
 #[tokio::test]
-async fn test_relay() {   // tests assume testnet in config
+async fn test_relay() {
+    // tests assume testnet in config
     // Test Transfer Action
-    let actions = vec![
-        Action::Transfer(TransferAction { deposit: 1 })
-    ];
-    let sender_id: String = String::from("relayer_test0.testnet");
-    let receiver_id: String = String::from("relayer_test1.testnet");
-    let nonce: i32 = 1;
+    let actions = vec![Action::Transfer(TransferAction { deposit: 1 })];
+    let sender_id: AccountId = "relayer_test0.testnet".parse().unwrap();
+    let receiver_id: AccountId = "relayer_test1.testnet".parse().unwrap();
+    let nonce = 1;
     let max_block_height = 2000000000;
 
     // Call the `relay` function happy path
-    let signed_delegate_action = create_signed_delegate_action(
-        sender_id.clone(),
-        receiver_id.clone(),
-        actions.clone(),
-        nonce,
-        max_block_height,
-    );
-    let json_payload = signed_delegate_action.try_to_vec().unwrap();
-    println!("SignedDelegateAction Json Serialized: {:?}", json_payload);
-    let response = relay(Json(Vec::from(json_payload))).await.into_response();
+    let signed_delegate_action =
+        create_signed_delegate_action(sender_id, receiver_id, actions, nonce, max_block_height);
+    let json_payload = crate::schemas::RelayInputArgs {
+        signed_delegate_action: signed_delegate_action.into(),
+    };
+    println!("SignedDelegateAction Json Serialized: {json_payload:?}");
+    let response = relay(Json(json_payload)).await.into_response();
     let response_status = response.status();
     assert_eq!(response_status, StatusCode::OK);
-
-    // Call the `relay` function with a payload that can't be deserialized into a SignedDelegateAction
-    let bad_json_payload = serde_json::to_string("arrrgh").unwrap();
-    println!("Malformed Json Payload Serialized: {:?}", bad_json_payload);
-    let err_response = relay(Json(Vec::from(bad_json_payload))).await.into_response();
-    let err_response_status = err_response.status();
-    assert_eq!(err_response_status, StatusCode::BAD_REQUEST);
 }
 
 #[tokio::test]
 #[ignore]
-async fn test_relay_with_load() {   // tests assume testnet in config
+async fn test_relay_with_load() {
+    // tests assume testnet in config
     // Test Transfer Action
-
-    let actions = vec![
-        Action::Transfer(TransferAction { deposit: 1 })
-    ];
-    let account_id0: String = "relayer_test0.testnet".to_string();
-    let account_id1: String = "relayer_test1.testnet".to_string();
-    let mut sender_id: String = String::new();
-    let mut receiver_id: String = String::new();
-    let mut nonce: i32 = 1;
+    let actions = vec![Action::Transfer(TransferAction { deposit: 1 })];
+    let mut sender_id: AccountId = "relayer_test0.testnet".parse().unwrap();
+    let mut receiver_id: AccountId = "relayer_test1.testnet".parse().unwrap();
+    let mut nonce = 1;
     let max_block_height = 2000000000;
 
     let num_tests = 100;
     let mut response_statuses = vec![];
 
     // fire off all post requests in rapid succession and save the response status codes
-    for i in 0..num_tests {
-        if i % 2 == 0 {
-            sender_id.push_str(&*account_id0.clone());
-            receiver_id.push_str(&*account_id1.clone());
-        } else {
-            sender_id.push_str(&*account_id1.clone());
-            receiver_id.push_str(&*account_id0.clone());
-        }
+    for _ in 0..num_tests {
         // Call the `relay` function happy path
         let signed_delegate_action = create_signed_delegate_action(
             sender_id.clone(),
@@ -298,18 +230,16 @@ async fn test_relay_with_load() {   // tests assume testnet in config
             nonce,
             max_block_height,
         );
-        let json_payload = signed_delegate_action.try_to_vec().unwrap();
-        let response = relay(Json(Vec::from(json_payload))).await.into_response();
+        let json_payload = crate::schemas::RelayInputArgs {
+            signed_delegate_action: signed_delegate_action.into(),
+        };
+        let response = relay(Json(json_payload)).await.into_response();
         response_statuses.push(response.status());
 
-        // increment nonce & reset sender, receiver strs
         nonce += 1;
-        sender_id.clear();
-        receiver_id.clear();
+        std::mem::swap(&mut sender_id, &mut receiver_id);
     }
 
     // all responses should be successful
-    for i in 0..response_statuses.len() {
-        assert_eq!(response_statuses[i], StatusCode::OK);
-    }
+    assert!(response_statuses.into_iter().all(|s| s == StatusCode::OK));
 }

--- a/src/rpc_conf.rs
+++ b/src/rpc_conf.rs
@@ -1,9 +1,6 @@
 /*
- For ApiKey data structure
- */
-
-use std::fmt::Debug;
-use color_eyre::Report;
+For ApiKey data structure
+*/
 
 #[derive(Eq, Hash, Clone, Debug, PartialEq)]
 pub struct ApiKey(pub near_jsonrpc_client::auth::ApiKey);
@@ -16,12 +13,12 @@ impl From<ApiKey> for near_jsonrpc_client::auth::ApiKey {
 
 impl std::fmt::Display for ApiKey {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        self.0.fmt(f)
+        write!(f, "{:?}", self.0)
     }
 }
 
 impl std::str::FromStr for ApiKey {
-    type Err = color_eyre::eyre::Report;
+    type Err = color_eyre::Report;
 
     fn from_str(api_key: &str) -> Result<Self, Self::Err> {
         Ok(Self(near_jsonrpc_client::auth::ApiKey::new(api_key)?))
@@ -30,8 +27,8 @@ impl std::str::FromStr for ApiKey {
 
 impl serde::ser::Serialize for ApiKey {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: serde::ser::Serializer
+    where
+        S: serde::ser::Serializer,
     {
         serializer.serialize_str(self.0.to_str().unwrap())
     }
@@ -39,18 +36,18 @@ impl serde::ser::Serialize for ApiKey {
 
 impl<'de> serde::de::Deserialize<'de> for ApiKey {
     fn deserialize<D>(deserializer: D) -> Result<ApiKey, D::Error>
-        where
-            D: serde::de::Deserializer<'de>,
+    where
+        D: serde::de::Deserializer<'de>,
     {
         String::deserialize(deserializer)?
             .parse()
-            .map_err(|err: color_eyre::eyre::Report| serde::de::Error::custom(err.to_string()))
+            .map_err(|err: color_eyre::Report| serde::de::Error::custom(err.to_string()))
     }
 }
 
 /*
- For RPCConfig data structure for creating the RPC connection
- */
+For RPCConfig data structure for creating the RPC connection
+*/
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct RPCConfig {
@@ -145,7 +142,7 @@ pub fn rpc_transaction_error(
     err: near_jsonrpc_client::errors::JsonRpcError<
         near_jsonrpc_client::methods::broadcast_tx_commit::RpcTransactionError,
     >,
-) -> Result<(), Report> {
+) -> Result<(), color_eyre::Report> {
     match &err {
         near_jsonrpc_client::errors::JsonRpcError::TransportError(_rpc_transport_error) => {
             println!("Transport error transaction.\nPlease wait. The next try to send this transaction is happening right now ...");

--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -1,0 +1,50 @@
+use near_primitives::borsh::BorshDeserialize;
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct RelayInputArgs {
+    pub signed_delegate_action: SignedDelegateActionAsBase64,
+}
+
+#[derive(Debug, Clone)]
+pub struct SignedDelegateActionAsBase64 {
+    inner: near_primitives::delegate_action::SignedDelegateAction,
+}
+
+impl std::str::FromStr for SignedDelegateActionAsBase64 {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self {
+            inner: near_primitives::delegate_action::SignedDelegateAction::try_from_slice(
+                &near_primitives::serialize::from_base64(s)
+                .map_err(|err| format!("parsing of signed delegate action failed due to base64 sequence being invalid: {}", err))?,
+            )
+            .map_err(|err| format!("delegate action could not be deserialized from borsh: {}", err))?,
+        })
+    }
+}
+
+impl From<SignedDelegateActionAsBase64> for near_primitives::delegate_action::SignedDelegateAction {
+    fn from(inner: SignedDelegateActionAsBase64) -> Self {
+        inner.inner
+    }
+}
+
+impl From<near_primitives::delegate_action::SignedDelegateAction> for SignedDelegateActionAsBase64 {
+    fn from(inner: near_primitives::delegate_action::SignedDelegateAction) -> Self {
+        Self { inner }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for SignedDelegateActionAsBase64 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let signed_delegate_action_as_base64 =
+            <String as serde::Deserialize>::deserialize(deserializer)?;
+        signed_delegate_action_as_base64
+            .parse()
+            .map_err(serde::de::Error::custom)
+    }
+}

--- a/src/signing.rs
+++ b/src/signing.rs
@@ -1,12 +1,11 @@
-use std::str::FromStr;
-use near_jsonrpc_client::JsonRpcClient;
+use serde::{Deserialize, Serialize};
+
 use near_crypto::{PublicKey, SecretKey};
+use near_jsonrpc_client::JsonRpcClient;
+use near_jsonrpc_primitives::types;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::AccountId;
-use serde::{Deserialize, Serialize};
-use near_jsonrpc_primitives::types;
 use near_primitives::views::QueryRequest;
-
 
 #[derive(Debug, Clone)]
 pub struct SigningKeys {
@@ -23,16 +22,14 @@ struct KeyFile {
 }
 
 fn read_key_file(filename: &str) -> Result<KeyFile, Box<dyn std::error::Error>> {
-    let file_contents = std::fs::read_to_string(filename)?;
-    let key_file = serde_json::from_str(&file_contents)?;
-    Ok(key_file)
+    Ok(serde_json::from_reader(std::fs::File::open(filename)?)?)
 }
 
 pub fn get_signing_keys(filename: &str) -> Result<SigningKeys, Box<dyn std::error::Error>> {
     let key_file = read_key_file(filename)?;
-    let account_id = AccountId::from_str(&key_file.account_id).unwrap();
-    let signer_public_key = PublicKey::from_str(&key_file.public_key)?;
-    let signer_private_key = SecretKey::from_str(&key_file.private_key)?;
+    let account_id = key_file.account_id.parse()?;
+    let signer_public_key = key_file.public_key.parse()?;
+    let signer_private_key = key_file.private_key.parse()?;
     Ok(SigningKeys {
         account_id,
         signer_public_key,
@@ -43,37 +40,36 @@ pub fn get_signing_keys(filename: &str) -> Result<SigningKeys, Box<dyn std::erro
 pub async fn sign_transaction(
     prepopulated_unsigned_transaction: near_primitives::transaction::Transaction,
     filename: &str,
-    json_rpc_client: JsonRpcClient,
-) -> color_eyre::eyre::Result<Option<SignedTransaction>> {
+    json_rpc_client: &JsonRpcClient,
+) -> color_eyre::eyre::Result<SignedTransaction> {
     let signing_keys = get_signing_keys(filename).unwrap();
     let signer_secret_key: SecretKey = signing_keys.signer_private_key.clone();
     let online_signer_access_key_response = json_rpc_client
         .call(near_jsonrpc_client::methods::query::RpcQueryRequest {
             block_reference: near_primitives::types::Finality::Final.into(),
             request: QueryRequest::ViewAccessKey {
-                account_id: signing_keys.account_id.clone(),
+                account_id: signing_keys.account_id,
                 public_key: signing_keys.signer_public_key.clone(),
             },
         })
         .await
         .map_err(|err| {
             println!("\nYour transaction was not successfully signed.\n");
-            color_eyre::Report::msg(format!(
+            color_eyre::eyre::eyre!(
                 "Failed to fetch public key information for nonce: {:?}",
                 err
-            ))
+            )
         })?;
     let current_nonce =
-        if let types::query::QueryResponseKind::AccessKey(
-            online_signer_access_key,
-        ) = online_signer_access_key_response.kind
+        if let types::query::QueryResponseKind::AccessKey(online_signer_access_key) =
+            online_signer_access_key_response.kind
         {
             online_signer_access_key.nonce
         } else {
-            return Err(color_eyre::Report::msg("Error current_nonce".to_string()));
+            return Err(color_eyre::eyre::eyre!("Error current_nonce"));
         };
     let unsigned_transaction = near_primitives::transaction::Transaction {
-        public_key: signing_keys.signer_public_key.clone(),
+        public_key: signing_keys.signer_public_key,
         block_hash: online_signer_access_key_response.block_hash,
         nonce: current_nonce + 1,
         ..prepopulated_unsigned_transaction
@@ -81,5 +77,5 @@ pub async fn sign_transaction(
     let signature = signer_secret_key.sign(unsigned_transaction.get_hash_and_size().0.as_ref());
     let signed_transaction = SignedTransaction::new(signature, unsigned_transaction);
     println!("\nYour transaction was signed successfully.");
-    Ok(Option::from(signed_transaction))
+    Ok(signed_transaction)
 }


### PR DESCRIPTION
**IT IS A BREAKING CHANGE**

Payload format to `relay` method before this change (the data is fake):

```json
[123, 200, 0, 13, 43, 203]
```

after this change:

```json
{
  "signed_delegate_action": "e30="
}
```

This new payload format is:
* more compact - JSON array of numbers requires 2-4 bytes per byte of the binary data while base64 only uses 1.4 bytes per byte
* faster to serialize/deserialize - JSON parsers have more overhead parsing an array of numbers than to parse a string value and then decode it with base64
* future-compatible - it is easy to add extra arguments to the `relay` method if necessary when you have an object since adding new methods is not a breaking change
* [near-cli-rs compatible](https://github.com/near/near-cli-rs/blob/05e4acaceb8f5673bf72a480e4271473593a54e5/src/transaction_signature_options/mod.rs#L184-L198)