### PR TITLE
Config improvements

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,3 @@
-# mainnet, testnet, shardnet, betanet are acceptable values for network
-# other networks can be used, but optional params below are required
-network = "testnet"
 # ip address to run server on, default to localhost
 ip_address = [0, 0, 0, 0]
 # port to expose
@@ -9,8 +6,6 @@ port = 3030
 relayer_account_id = "nomnomnom.testnet"   # "relayer.pagodaplatform.near"
 # replace with json files containing 3 entries: account_id (should match relayer_account_id), public_key, private_key
 keys_filenames = ["./account_keys/nomnomnom.testnet.json", "./account_keys/37cb5b936de257d014e663663b186e58e4c3c4c9b4c7643e7b89821e789b0b4b.json", "./account_keys/b278b7752b844a0cc88f8dbdb053b860d6283fb353e7a317b3b82efe01396c3e.json", "./account_keys/d7adc371186bc2013ec5de36be27ed9a36022af1112f7c62530baf6042690f61.json", "./account_keys/df86e9701801e30cf0649b2ea43aeacef60e394e076709d4519880d5a9c7bc9e.json", "./account_keys/e4a6dd159d45d4104679e709d29d49a533e5df9467b311c9dbea7fb8f0077335.json"] # "relayer.pagodaplatform.json"
-# number of keys in keys_filenames
-num_keys = 6
 # replace with the account id of the public key you will use to sign shared_storage transactions - this should match the account_id in your json file
 shared_storage_account_id = "relayer-test.testnet"  # "social-storage.pagodaplatform.near"
 # replace with json file containing 3 entries: account_id (should match shared_storage_account_id), public_key, private_key
@@ -31,6 +26,4 @@ override_rpc_conf = false
 #explorer_transaction_url = "https://explorer.testnet.near.org/transactions/"
 #rpc_api_key = ""
 
-[social_db]
-mainnet = "social.near"
-testnet = "v1.social08.testnet"
+social_db_contract = "v1.social08.testnet"

--- a/config.toml
+++ b/config.toml
@@ -17,13 +17,30 @@ whitelisted_delegate_action_receiver_ids = ["account_creator.near", "relayer_tes
 # redis url for storing and retrieving account_id, allowance
 redis_url = "redis://127.0.0.1:6379"
 
-# ------------------------ OPTIONAL ------------------------
-# change to true if you're overriding defaults
-override_rpc_conf = false
-# only uncomment & change if you want to override defaults set in rpc_conf.rs
-#rpc_url = "https://archival-rpc.testnet.near.org"
-#wallet_url = "https://wallet.testnet.near.org"
-#explorer_transaction_url = "https://explorer.testnet.near.org/transactions/"
-#rpc_api_key = ""
+social_db_contract_id = "v1.social08.testnet"
 
-social_db_contract = "v1.social08.testnet"
+# Uncoment the network you want to use or add your own
+
+# mainnet
+# rpc_url = "https://rpc.mainnet.near.org"
+# wallet_url = "https://wallet.mainnet.near.org"
+# explorer_transaction_url = "https://explorer.mainnet.near.org/transactions/"
+# rpc_api_key = ""
+
+# testnet
+rpc_url = "https://archival-rpc.testnet.near.org"
+wallet_url = "https://wallet.testnet.near.org"
+explorer_transaction_url = "https://explorer.testnet.near.org/transactions/"
+rpc_api_key = ""
+
+# betanet
+# rpc_url = "https://rpc.betanet.near.org"
+# wallet_url = "https://wallet.betanet.near.org"
+# explorer_transaction_url = "https://explorer.betanet.near.org/transactions/"
+# rpc_api_key = ""
+
+# shardnet
+# rpc_url = "https://rpc.shardnet.near.org"
+# wallet_url = "https://wallet.shardnet.near.org"
+# explorer_transaction_url = "https://explorer.shardnet.near.org/transactions/"
+# rpc_api_key = ""

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@ use tracing::log::error;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 use crate::error::RelayError;
-use crate::rpc_conf::{NetworkConfig, RPCConfig};
+use crate::rpc_conf::NetworkConfig;
 use crate::shared_storage::SharedStoragePoolManager;
 
 
@@ -68,24 +68,13 @@ static LOCAL_CONF: Lazy<Config> = Lazy::new(|| {
 });
 static NETWORK_ENV: Lazy<String> = Lazy::new(|| { LOCAL_CONF.get("network").unwrap() });
 static JSON_RPC_CLIENT: Lazy<near_jsonrpc_client::JsonRpcClient> = Lazy::new(|| {
-    let network_name: String = LOCAL_CONF.get("network").unwrap();
-    let rpc_config = RPCConfig::default();
-
-    // optional overrides
-    if LOCAL_CONF.get::<bool>("override_rpc_conf").unwrap() {
-        let network_config = NetworkConfig {
-            network_name,
-            rpc_url: LOCAL_CONF.get("rpc_url").unwrap(),
-            rpc_api_key: LOCAL_CONF.get("rpc_api_key").unwrap(),
-            wallet_url: LOCAL_CONF.get("wallet_url").unwrap(),
-            explorer_transaction_url: LOCAL_CONF.get("explorer_transaction_url").unwrap(),
-        };
-        network_config.json_rpc_client()
-    } else {
-        let network_config = rpc_config.networks.get(&network_name).unwrap();
-        network_config.json_rpc_client()
-    }
-
+    let network_config = NetworkConfig {
+        rpc_url: LOCAL_CONF.get("rpc_url").unwrap(),
+        rpc_api_key: LOCAL_CONF.get("rpc_api_key").unwrap(),
+        wallet_url: LOCAL_CONF.get("wallet_url").unwrap(),
+        explorer_transaction_url: LOCAL_CONF.get("explorer_transaction_url").unwrap(),
+    };
+    network_config.json_rpc_client()
 });
 static IP_ADDRESS: Lazy<[u8; 4]> = Lazy::new(|| { LOCAL_CONF.get("ip_address").unwrap() });
 static PORT: Lazy<u16> = Lazy::new(|| { LOCAL_CONF.get("port").unwrap() });
@@ -114,7 +103,7 @@ static REDIS_POOL: Lazy<Pool<RedisConnectionManager>> = Lazy::new(|| {
     Pool::builder().build(manager).unwrap()
 });
 static SHARED_STORAGE_POOL: Lazy<SharedStoragePoolManager> = Lazy::new(|| {
-    let social_db_id: String = LOCAL_CONF.get("social_db_contract").unwrap();
+    let social_db_id: String = LOCAL_CONF.get("social_db_contract_id").unwrap();
 
     SharedStoragePoolManager::new(
         &SHARED_STORAGE_KEYS_FILENAME,

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,7 +99,6 @@ static KEYS_FILENAMES: Lazy<Vec<String>> = Lazy::new(|| {
     LOCAL_CONF.get::<Vec<String>>("keys_filenames")
         .expect("Failed to read 'keys_filenames' from config")
 });
-static KEYS_FILENAMES_LEN: Lazy<usize> = Lazy::new(||{ LOCAL_CONF.get("num_keys").unwrap() });
 static SHARED_STORAGE_KEYS_FILENAME: Lazy<String> = Lazy::new(|| {
     LOCAL_CONF.get("shared_storage_keys_filename").unwrap()
 });
@@ -115,9 +114,7 @@ static REDIS_POOL: Lazy<Pool<RedisConnectionManager>> = Lazy::new(|| {
     Pool::builder().build(manager).unwrap()
 });
 static SHARED_STORAGE_POOL: Lazy<SharedStoragePoolManager> = Lazy::new(|| {
-    let network_name: String = LOCAL_CONF.get("network").unwrap();
-    let mut social: serde_json::Map<String, serde_json::Value> = LOCAL_CONF.get("social_db").unwrap();
-    let social_db_id: String = serde_json::from_value(social.remove(&network_name).unwrap()).unwrap();
+    let social_db_id: String = LOCAL_CONF.get("social_db_contract").unwrap();
 
     SharedStoragePoolManager::new(
         &SHARED_STORAGE_KEYS_FILENAME,
@@ -145,7 +142,7 @@ impl IndexCounter {
     }
 }
 static IDX_COUNTER: Lazy<Arc<Mutex<IndexCounter>>> = Lazy::new(|| {
-    let max_idx: usize = *KEYS_FILENAMES_LEN;
+    let max_idx: usize = KEYS_FILENAMES.len();
     let idx_counter: IndexCounter = IndexCounter::new(max_idx);
     Arc::new(Mutex::new(idx_counter))
 });

--- a/src/rpc_conf.rs
+++ b/src/rpc_conf.rs
@@ -59,73 +59,10 @@ pub struct RPCConfig {
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct NetworkConfig {
-    pub network_name: String,
     pub rpc_url: url::Url,
     pub rpc_api_key: Option<ApiKey>,
     pub wallet_url: url::Url,
     pub explorer_transaction_url: url::Url,
-}
-
-impl Default for RPCConfig {
-    fn default() -> Self {
-        let home_dir = dirs::home_dir().expect("Impossible to get your home dir!");
-        let mut credentials_home_dir = std::path::PathBuf::from(&home_dir);
-        credentials_home_dir.push(".near-credentials");
-
-        let mut networks = linked_hash_map::LinkedHashMap::new();
-        networks.insert(
-            "mainnet".to_string(),
-            NetworkConfig {
-                network_name: "mainnet".to_string(),
-                rpc_url: "https://rpc.mainnet.near.org".parse().unwrap(),
-                wallet_url: "https://wallet.mainnet.near.org".parse().unwrap(),
-                explorer_transaction_url: "https://explorer.mainnet.near.org/transactions/"
-                    .parse()
-                    .unwrap(),
-                rpc_api_key: None,
-            },
-        );
-        networks.insert(
-            "testnet".to_string(),
-            NetworkConfig {
-                network_name: "testnet".to_string(),
-                rpc_url: "https://rpc.testnet.near.org".parse().unwrap(),
-                wallet_url: "https://wallet.testnet.near.org".parse().unwrap(),
-                explorer_transaction_url: "https://explorer.testnet.near.org/transactions/"
-                    .parse()
-                    .unwrap(),
-                rpc_api_key: None,
-            },
-        );
-        networks.insert(
-            "betanet".to_string(),
-            NetworkConfig {
-                network_name: "betanet".to_string(),
-                rpc_url: "https://rpc.betanet.near.org".parse().unwrap(),
-                wallet_url: "https://wallet.betanet.near.org".parse().unwrap(),
-                explorer_transaction_url: "https://explorer.betanet.near.org/transactions/"
-                    .parse()
-                    .unwrap(),
-                rpc_api_key: None,
-            },
-        );
-        networks.insert(
-            "shardnet".to_string(),
-            NetworkConfig {
-                network_name: "shardnet".to_string(),
-                rpc_url: "https://rpc.shardnet.near.org".parse().unwrap(),
-                wallet_url: "https://wallet.shardnet.near.org".parse().unwrap(),
-                explorer_transaction_url: "https://explorer.shardnet.near.org/transactions/"
-                    .parse()
-                    .unwrap(),
-                rpc_api_key: None,
-            },
-        );
-        Self {
-            credentials_home_dir,
-            networks,
-        }
-    }
 }
 
 impl NetworkConfig {

--- a/src/rpc_conf.rs
+++ b/src/rpc_conf.rs
@@ -2,7 +2,6 @@
  For ApiKey data structure
  */
 
-use color_eyre::Report;
 use std::fmt::Debug;
 
 #[derive(Eq, Hash, Clone, Debug, PartialEq)]


### PR DESCRIPTION
- `num_keys` removed, can be determined in runtime
- `network` removed, let's not mix configs in code and toml file, it's hard to understand and predict behavior without looking into code. Relayer should not know about the existence of any specific networks.
- same reasons for changes in `social_db_contract_id`

We still have .near and .testnet accounts in one array. As a next step we can separate mainnet, testnet etc. envs into separate files like "testnet_config.toml".