### PR TITLE
multiple example configs for different relayer use cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The `SignedTransaction` is then sent to the network via RPC call and the result 
 3. As an enterprise or a large startup you want to seamlessly onboard your existing users onto NEAR without needing them to worry about gas costs and seed phrases
 4. As an enterprise or large startup you have a userbase that can generate large spikes of user activity that would congest the network. In this case, the relayer acts as a queue for low urgency transactions  
 5. In exchange for covering the gas fee costs, relayer operators can limit where users spend their assets while allowing users to have custody and ownership of their assets 
+6. Capital Efficiency: Without relayer if your business has 1M users they would have to be allocated 0.25 NEAR to cover their gas costs totalling 250k NEAR. However, only ~10% of the users would actually use the full allowance and a large amount of the 250k NEAR is just sitting there unused. So using the relayer, you can allocate 50k NEAR as a global pool of capital for your users, which can refilled on an as needed basis.
 
 ## Features 
 NOTE: These features can be mixed and matched "à la carte". Use of one feature does not preclude the use of any other feature unless specified. See the `/examples` directory for example configs corresponding to different use cases.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ NOTE: These features can be mixed and matched "à la carte". Use of one feature 
 4. Specify the accounts for which the relayer will cover gas fees (`whitelisted_delegate_action_receiver_ids` in `config.toml`)
 5. Only allow users to register if they have a unique Oauth Token (`/create_account_atomic`, `/register_account`)
 6. Relayer Key Rotation: `keys_filenames` in `config.toml`
+7. Integrate with [Fastauth SDK](https://docs.near.org/tools/fastauth-sdk). See `/examples/configs/fastauth.toml`
 
 ### Features - COMING SOON
 1. Allow users to pay for gas fees using Fungible Tokens they hold. This can be implemented by either:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The `SignedTransaction` is then sent to the network via RPC call and the result 
 5. In exchange for covering the gas fee costs, relayer operators can limit where users spend their assets while allowing users to have custody and ownership of their assets 
 
 ## Features 
-NOTE: These features can be mixed and matched "à la carte". Use of one feature does not preclude the use of any other feature unless specified.
+NOTE: These features can be mixed and matched "à la carte". Use of one feature does not preclude the use of any other feature unless specified. See the `/examples` directory for example configs corresponding to different use cases.
 1. Cover the gas costs of end users while allowing them to maintain custody of their funds and approve transactions (`/relay`, `/send_meta_tx`)
 2. Only pay for users interacting with certain contracts by whitelisting contracts addresses (`whitelisted_contracts` in `config.toml`) 
 3. Specify gas cost allowances for all accounts (`/update_all_allowances`) or on a per-user account basis (`/create_account_atomic`, `/register_account`, `/update_allowance`) and keep track of allowances (`/get_allowance`)

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ NOTE: this is only needed if you intend to use whitelisting, allowances, and oau
 2. Run `redis-server --bind 127.0.0.1 --port 6379` - make sure the port matches the `redis_url` in the `config.toml`.
 3. Run `redis-cli -h 127.0.0.1 -p 6379`
 
-## Multiple Key Generation - OPTIONAL
+## Multiple Key Generation - OPTIONAL, but recommended for high throughput to prevent nonce race conditions
 1. [Install NEAR CLI](https://docs.near.org/tools/near-cli#installation)
 2. Make sure you're using the appropriate network: `echo $NEAR_ENV`. To change it, `export NEAR_ENV=testnet` 
 3. Make sure your keys you want to use for the relayer have a `'FullAccess'` access_key by running `near keys your_relayer_account.testnet`. This is required to create more keys. You need to have access to at least 1 `'FullAccess'` access_key 

--- a/config.toml
+++ b/config.toml
@@ -1,3 +1,5 @@
+# This is a config that should be updated. See /examples directory for example configs corresponding to different use cases.
+
 # ip address to run server on, default to localhost
 ip_address = [0, 0, 0, 0]
 # port to expose

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,5 @@
 # This is a config that should be updated. See /examples directory for example configs corresponding to different use cases.
+# PLEASE READ THE COMMENTS IN THIS FILE
 
 # ip address to run server on, default to localhost
 ip_address = [0, 0, 0, 0]
@@ -26,7 +27,8 @@ redis_url = "redis://127.0.0.1:6379"
 # including check if sender id and receiver id are the same AND (AddKey or DeleteKey action) in process_signed_delegate_action fn
 # and you're using shared storage contract
 use_fastauth_features = false
-# you can still use shared storage without fastauth features if you desire
+# you can still use shared storage without fastauth features if you desire,
+# but needs to be set to true if using fastauth or the contract you're sending transactions to requires a storage deposit
 use_shared_storage = false
 social_db_contract_id = "v1.social08.testnet"
 

--- a/config.toml
+++ b/config.toml
@@ -8,6 +8,7 @@ port = 3030
 # replace with the account id of the public key you will use to sign relay transactions - this should match the account_id in your json file
 relayer_account_id = "nomnomnom.testnet"   # "relayer.pagodaplatform.near"
 # replace with json files containing 3 entries: account_id (should match relayer_account_id), public_key, private_key
+# this is recommended for high throughput use cases to prevent nonce race conditions
 keys_filenames = ["./account_keys/nomnomnom.testnet.json", "./account_keys/37cb5b936de257d014e663663b186e58e4c3c4c9b4c7643e7b89821e789b0b4b.json", "./account_keys/b278b7752b844a0cc88f8dbdb053b860d6283fb353e7a317b3b82efe01396c3e.json", "./account_keys/d7adc371186bc2013ec5de36be27ed9a36022af1112f7c62530baf6042690f61.json", "./account_keys/df86e9701801e30cf0649b2ea43aeacef60e394e076709d4519880d5a9c7bc9e.json", "./account_keys/e4a6dd159d45d4104679e709d29d49a533e5df9467b311c9dbea7fb8f0077335.json"] # "relayer.pagodaplatform.json"
 # replace with the account id of the public key you will use to sign shared_storage transactions - this should match the account_id in your json file
 shared_storage_account_id = "relayer-test.testnet"  # "social-storage.pagodaplatform.near"

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,4 +9,9 @@ Please note that these are for reference only and you should be updating the val
 - `redis.toml`
   - This is a config for a relayer that covers gas for user transactions up to a allowance specified in Redis to interact with a whitelisted set of contracts. 
   - Allowances are on a per-account id basis and on signup (account creation in redis and on-chain) an oauth token is required to help with sybil resistance
-- 
+- `fastauth.toml`
+  - This is a config for use if you intend to integrate with [fastuath sdk](https://docs.near.org/tools/fastauth-sdk)
+  - It covers gas for user transactions up to a allowance specified in Redis to interact with a whitelisted set of contracts. 
+  - Allowances are on a per-account id basis and on signup (account creation in redis and on-chain) an oauth token is required to help with sybil resistance 
+  - This also makes use of a shared storage functionality on the near social db contract 
+  - and a whitelisted sender (whitelisted_delegate_action_receiver_ids)

--- a/examples/README.md
+++ b/examples/README.md
@@ -15,3 +15,5 @@ Please note that these are for reference only and you should be updating the val
   - Allowances are on a per-account id basis and on signup (account creation in redis and on-chain) an oauth token is required to help with sybil resistance 
   - This also makes use of a shared storage functionality on the near social db contract 
   - and a whitelisted sender (whitelisted_delegate_action_receiver_ids)
+- `pay_with_ft.toml` 
+  - This is a config for a relayer that ensures there's FTs sent to a burn address used to cover the equivalent amount of gas for user transactions to interact with a whitelisted set of contracts 

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,3 +2,11 @@
 This directory contains example configs corresponding to different use cases. 
 
 Please note that these are for reference only and you should be updating the values in the `config.toml` file found in the `pagoda-relayer-rs` directory.
+
+## Configs and Usecases
+- `basic_whitelist.toml`
+  - This is a config for a basic relayer that covers gas for user transactions to interact with a whitelisted set of contracts
+- `redis.toml`
+  - This is a config for a relayer that covers gas for user transactions up to a allowance specified in Redis to interact with a whitelisted set of contracts. 
+  - Allowances are on a per-account id basis and on signup (account creation in redis and on-chain) an oauth token is required to help with sybil resistance
+- 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,4 @@
+# Example Configs 
+This directory contains example configs corresponding to different use cases. 
+
+Please note that these are for reference only and you should be updating the values in the `config.toml` file found in the `pagoda-relayer-rs` directory.

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,3 +17,5 @@ Please note that these are for reference only and you should be updating the val
   - and a whitelisted sender (whitelisted_delegate_action_receiver_ids)
 - `pay_with_ft.toml` 
   - This is a config for a relayer that ensures there's FTs sent to a burn address used to cover the equivalent amount of gas for user transactions to interact with a whitelisted set of contracts 
+- `whitelist_senders.toml` (whitelisted_delegate_action_receiver_ids)
+  - This is a config for a relayer that covers gas for a whitelisted set of users' transactions to interact with a whitelisted set of contracts

--- a/examples/configs/basic_whitelist.toml
+++ b/examples/configs/basic_whitelist.toml
@@ -10,6 +10,7 @@ port = 3030
 # replace with the account id of the public key you will use to sign relay transactions - this should match the account_id in your json file
 relayer_account_id = "nomnomnom.testnet"
 # replace with json files containing 3 entries: account_id (should match relayer_account_id), public_key, private_key
+# this is recommended for high throughput use cases to prevent nonce race conditions
 keys_filenames = ["./account_keys/nomnomnom.testnet.json", "./account_keys/37cb5b936de257d014e663663b186e58e4c3c4c9b4c7643e7b89821e789b0b4b.json", "./account_keys/b278b7752b844a0cc88f8dbdb053b860d6283fb353e7a317b3b82efe01396c3e.json", "./account_keys/d7adc371186bc2013ec5de36be27ed9a36022af1112f7c62530baf6042690f61.json", "./account_keys/df86e9701801e30cf0649b2ea43aeacef60e394e076709d4519880d5a9c7bc9e.json", "./account_keys/e4a6dd159d45d4104679e709d29d49a533e5df9467b311c9dbea7fb8f0077335.json"]
 # whitelisted contract ids (receiver_id)
 whitelisted_contracts = ["nomnomnom.testnet", "relayer_test0.testnet", "relayer_test1.testnet"]

--- a/examples/configs/basic_whitelist.toml
+++ b/examples/configs/basic_whitelist.toml
@@ -1,0 +1,38 @@
+# Basic Whitelist config
+# This is a config for a basic relayer that covers gas for user transactions to interact with a whitelisted set of contracts
+
+# ip address to run server on, default to localhost
+ip_address = [0, 0, 0, 0]
+# port to expose
+port = 3030
+# replace with the account id of the public key you will use to sign relay transactions - this should match the account_id in your json file
+relayer_account_id = "nomnomnom.testnet"
+# replace with json files containing 3 entries: account_id (should match relayer_account_id), public_key, private_key
+keys_filenames = ["./account_keys/nomnomnom.testnet.json", "./account_keys/37cb5b936de257d014e663663b186e58e4c3c4c9b4c7643e7b89821e789b0b4b.json", "./account_keys/b278b7752b844a0cc88f8dbdb053b860d6283fb353e7a317b3b82efe01396c3e.json", "./account_keys/d7adc371186bc2013ec5de36be27ed9a36022af1112f7c62530baf6042690f61.json", "./account_keys/df86e9701801e30cf0649b2ea43aeacef60e394e076709d4519880d5a9c7bc9e.json", "./account_keys/e4a6dd159d45d4104679e709d29d49a533e5df9467b311c9dbea7fb8f0077335.json"]
+# whitelisted contract ids (receiver_id)
+whitelisted_contracts = ["nomnomnom.testnet", "relayer_test0.testnet", "relayer_test1.testnet"]
+# if this is set to false, just call /send_meta_tx or /relay endpoints. All other endpoints are coupled with using redis
+# this needs to be set to true if use_fastauth_features = true
+use_redis = false
+
+# set use_fastauth_features to true if you're integrating with fastauth -
+# including check if sender id and receiver id are the same AND (AddKey or DeleteKey action) in process_signed_delegate_action fn
+# and you're using shared storage contract
+use_fastauth_features = false
+# you can still use shared storage without fastauth features if you desire,
+# but needs to be set to true if using fastauth or the contract you're sending transactions to requires a storage deposit
+use_shared_storage = false
+
+# Uncoment the network you want to use or add your own
+
+# mainnet
+# rpc_url = "https://rpc.mainnet.near.org"
+# wallet_url = "https://wallet.mainnet.near.org"
+# explorer_transaction_url = "https://explorer.mainnet.near.org/transactions/"
+# rpc_api_key = ""
+
+# testnet
+rpc_url = "https://archival-rpc.testnet.near.org"
+wallet_url = "https://wallet.testnet.near.org"
+explorer_transaction_url = "https://explorer.testnet.near.org/transactions/"
+rpc_api_key = ""

--- a/examples/configs/basic_whitelist.toml
+++ b/examples/configs/basic_whitelist.toml
@@ -1,5 +1,6 @@
 # Basic Whitelist config
 # This is a config for a basic relayer that covers gas for user transactions to interact with a whitelisted set of contracts
+
 # Please note this is for reference only and you should be updating the values in the `config.toml` file found in the `pagoda-relayer-rs` directory.
 
 # ip address to run server on, default to localhost

--- a/examples/configs/fastauth.toml
+++ b/examples/configs/fastauth.toml
@@ -52,15 +52,3 @@ rpc_url = "https://archival-rpc.testnet.near.org"
 wallet_url = "https://wallet.testnet.near.org"
 explorer_transaction_url = "https://explorer.testnet.near.org/transactions/"
 rpc_api_key = ""
-
-# betanet
-# rpc_url = "https://rpc.betanet.near.org"
-# wallet_url = "https://wallet.betanet.near.org"
-# explorer_transaction_url = "https://explorer.betanet.near.org/transactions/"
-# rpc_api_key = ""
-
-# shardnet
-# rpc_url = "https://rpc.shardnet.near.org"
-# wallet_url = "https://wallet.shardnet.near.org"
-# explorer_transaction_url = "https://explorer.shardnet.near.org/transactions/"
-# rpc_api_key = ""

--- a/examples/configs/fastauth.toml
+++ b/examples/configs/fastauth.toml
@@ -15,6 +15,7 @@ port = 3030
 # replace with the account id of the public key you will use to sign relay transactions - this should match the account_id in your json file
 relayer_account_id = "nomnomnom.testnet"   # "relayer.pagodaplatform.near"
 # replace with json files containing 3 entries: account_id (should match relayer_account_id), public_key, private_key
+# this is recommended for high throughput use cases to prevent nonce race conditions
 keys_filenames = ["./account_keys/nomnomnom.testnet.json", "./account_keys/37cb5b936de257d014e663663b186e58e4c3c4c9b4c7643e7b89821e789b0b4b.json", "./account_keys/b278b7752b844a0cc88f8dbdb053b860d6283fb353e7a317b3b82efe01396c3e.json", "./account_keys/d7adc371186bc2013ec5de36be27ed9a36022af1112f7c62530baf6042690f61.json", "./account_keys/df86e9701801e30cf0649b2ea43aeacef60e394e076709d4519880d5a9c7bc9e.json", "./account_keys/e4a6dd159d45d4104679e709d29d49a533e5df9467b311c9dbea7fb8f0077335.json"] # "relayer.pagodaplatform.json"
 # replace with the account id of the public key you will use to sign shared_storage transactions - this should match the account_id in your json file
 shared_storage_account_id = "relayer-test.testnet"

--- a/examples/configs/fastauth.toml
+++ b/examples/configs/fastauth.toml
@@ -1,0 +1,66 @@
+# Fastauth Config
+# This is a config for use if you intend to integrate with [fastuath sdk](https://docs.near.org/tools/fastauth-sdk)
+# It covers gas for user transactions up to a allowance specified in Redis to interact with a whitelisted set of contracts.
+# Allowances are on a per account id basis and on signup (account creation in redis and on-chain) an oauth token is required to help with sybil resistance
+# This also makes use of a shared storage functionality on the near social db contract
+# and a whitelisted sender (whitelisted_delegate_action_receiver_ids)
+
+# Please note this is for reference only and you should be updating the values in the `config.toml` file found in the `pagoda-relayer-rs` directory.
+
+
+# ip address to run server on, default to localhost
+ip_address = [0, 0, 0, 0]
+# port to expose
+port = 3030
+# replace with the account id of the public key you will use to sign relay transactions - this should match the account_id in your json file
+relayer_account_id = "nomnomnom.testnet"   # "relayer.pagodaplatform.near"
+# replace with json files containing 3 entries: account_id (should match relayer_account_id), public_key, private_key
+keys_filenames = ["./account_keys/nomnomnom.testnet.json", "./account_keys/37cb5b936de257d014e663663b186e58e4c3c4c9b4c7643e7b89821e789b0b4b.json", "./account_keys/b278b7752b844a0cc88f8dbdb053b860d6283fb353e7a317b3b82efe01396c3e.json", "./account_keys/d7adc371186bc2013ec5de36be27ed9a36022af1112f7c62530baf6042690f61.json", "./account_keys/df86e9701801e30cf0649b2ea43aeacef60e394e076709d4519880d5a9c7bc9e.json", "./account_keys/e4a6dd159d45d4104679e709d29d49a533e5df9467b311c9dbea7fb8f0077335.json"] # "relayer.pagodaplatform.json"
+# replace with the account id of the public key you will use to sign shared_storage transactions - this should match the account_id in your json file
+shared_storage_account_id = "relayer-test.testnet"
+# replace with json file containing 3 entries: account_id (should match shared_storage_account_id), public_key, private_key
+shared_storage_keys_filename = "relayer-test.testnet.json"
+# whitelisted contract ids (receiver_id)
+whitelisted_contracts = ["relayer_test0.testnet"]
+# check if this is a whitelisted sender - to run without this feature, then set use_fastauth_features = false below
+whitelisted_delegate_action_receiver_ids = ["relayer_test1.testnet"]
+# if this is set to false, just call /send_meta_tx or /relay endpoints. All other endpoints are coupled with using redis
+# this needs to be set to true if use_fastauth_features = true
+use_redis = true
+# redis url for storing and retrieving allowance for an account_id and seeing if an oauth_token has been used before
+redis_url = "redis://127.0.0.1:6379"
+
+# set use_fastauth_features to true if you're integrating with fastauth -
+# including check if sender id and receiver id are the same AND (AddKey or DeleteKey action) in process_signed_delegate_action fn
+# and you're using shared storage contract
+use_fastauth_features = true
+# you can still use shared storage without fastauth features if you desire,
+# but needs to be set to true if using fastauth or the contract you're sending transactions to requires a storage deposit
+use_shared_storage = true
+social_db_contract_id = "v1.social08.testnet"
+
+# Uncoment the network you want to use or add your own
+
+# mainnet
+# rpc_url = "https://rpc.mainnet.near.org"
+# wallet_url = "https://wallet.mainnet.near.org"
+# explorer_transaction_url = "https://explorer.mainnet.near.org/transactions/"
+# rpc_api_key = ""
+
+# testnet
+rpc_url = "https://archival-rpc.testnet.near.org"
+wallet_url = "https://wallet.testnet.near.org"
+explorer_transaction_url = "https://explorer.testnet.near.org/transactions/"
+rpc_api_key = ""
+
+# betanet
+# rpc_url = "https://rpc.betanet.near.org"
+# wallet_url = "https://wallet.betanet.near.org"
+# explorer_transaction_url = "https://explorer.betanet.near.org/transactions/"
+# rpc_api_key = ""
+
+# shardnet
+# rpc_url = "https://rpc.shardnet.near.org"
+# wallet_url = "https://wallet.shardnet.near.org"
+# explorer_transaction_url = "https://explorer.shardnet.near.org/transactions/"
+# rpc_api_key = ""

--- a/examples/configs/pay_with_ft.toml
+++ b/examples/configs/pay_with_ft.toml
@@ -1,0 +1,48 @@
+# Pay with Fungible Token config
+# This is a config for a relayer that ensures there's FTs sent to a burn address used to cover the equivalent amount of gas
+# for user transactions to interact with a whitelisted set of contracts
+
+# Please note this is for reference only and you should be updating the values in the `config.toml` file found in the `pagoda-relayer-rs` directory.
+
+# ip address to run server on, default to localhost
+ip_address = [0, 0, 0, 0]
+# port to expose
+port = 3030
+# replace with the account id of the public key you will use to sign relay transactions - this should match the account_id in your json file
+relayer_account_id = "nomnomnom.testnet"
+# replace with json files containing 3 entries: account_id (should match relayer_account_id), public_key, private_key
+keys_filenames = ["./account_keys/nomnomnom.testnet.json", "./account_keys/37cb5b936de257d014e663663b186e58e4c3c4c9b4c7643e7b89821e789b0b4b.json", "./account_keys/b278b7752b844a0cc88f8dbdb053b860d6283fb353e7a317b3b82efe01396c3e.json", "./account_keys/d7adc371186bc2013ec5de36be27ed9a36022af1112f7c62530baf6042690f61.json", "./account_keys/df86e9701801e30cf0649b2ea43aeacef60e394e076709d4519880d5a9c7bc9e.json", "./account_keys/e4a6dd159d45d4104679e709d29d49a533e5df9467b311c9dbea7fb8f0077335.json"]
+# whitelisted contract ids (receiver_id)
+whitelisted_contracts = ["nomnomnom.testnet", "relayer_test0.testnet", "relayer_test1.testnet"]
+# if this is set to false, just call /send_meta_tx or /relay endpoints. All other endpoints are coupled with using redis
+# this needs to be set to true if use_fastauth_features = true
+use_redis = false
+
+# set use_fastauth_features to true if you're integrating with fastauth -
+# including check if sender id and receiver id are the same AND (AddKey or DeleteKey action) in process_signed_delegate_action fn
+# and you're using shared storage contract
+use_fastauth_features = false
+# you can still use shared storage without fastauth features if you desire,
+# but needs to be set to true if using fastauth or the contract you're sending transactions to requires a storage deposit
+use_shared_storage = false
+
+# set use_pay_with_ft to true if your users have an FT balance but no NEAR
+use_pay_with_ft = true
+# check if there is an FT transfer to this burn address
+burn_address = "" # TODO
+# TODO integrate with oracle for FT value
+# TODO integrate this in code
+
+# Uncoment the network you want to use or add your own
+
+# mainnet
+# rpc_url = "https://rpc.mainnet.near.org"
+# wallet_url = "https://wallet.mainnet.near.org"
+# explorer_transaction_url = "https://explorer.mainnet.near.org/transactions/"
+# rpc_api_key = ""
+
+# testnet
+rpc_url = "https://archival-rpc.testnet.near.org"
+wallet_url = "https://wallet.testnet.near.org"
+explorer_transaction_url = "https://explorer.testnet.near.org/transactions/"
+rpc_api_key = ""

--- a/examples/configs/pay_with_ft.toml
+++ b/examples/configs/pay_with_ft.toml
@@ -29,9 +29,7 @@ use_shared_storage = false
 # set use_pay_with_ft to true if your users have an FT balance but no NEAR
 use_pay_with_ft = true
 # check if there is an FT transfer to this burn address
-burn_address = "" # TODO
-# TODO integrate with oracle for FT value
-# TODO integrate this in code
+burn_address = "burn.example.testnet"
 
 # Uncoment the network you want to use or add your own
 

--- a/examples/configs/pay_with_ft.toml
+++ b/examples/configs/pay_with_ft.toml
@@ -11,6 +11,7 @@ port = 3030
 # replace with the account id of the public key you will use to sign relay transactions - this should match the account_id in your json file
 relayer_account_id = "nomnomnom.testnet"
 # replace with json files containing 3 entries: account_id (should match relayer_account_id), public_key, private_key
+# this is recommended for high throughput use cases to prevent nonce race conditions
 keys_filenames = ["./account_keys/nomnomnom.testnet.json", "./account_keys/37cb5b936de257d014e663663b186e58e4c3c4c9b4c7643e7b89821e789b0b4b.json", "./account_keys/b278b7752b844a0cc88f8dbdb053b860d6283fb353e7a317b3b82efe01396c3e.json", "./account_keys/d7adc371186bc2013ec5de36be27ed9a36022af1112f7c62530baf6042690f61.json", "./account_keys/df86e9701801e30cf0649b2ea43aeacef60e394e076709d4519880d5a9c7bc9e.json", "./account_keys/e4a6dd159d45d4104679e709d29d49a533e5df9467b311c9dbea7fb8f0077335.json"]
 # whitelisted contract ids (receiver_id)
 whitelisted_contracts = ["nomnomnom.testnet", "relayer_test0.testnet", "relayer_test1.testnet"]

--- a/examples/configs/redis.toml
+++ b/examples/configs/redis.toml
@@ -1,5 +1,7 @@
-# Basic Whitelist config
-# This is a config for a basic relayer that covers gas for user transactions to interact with a whitelisted set of contracts
+# Redis config
+# This is a config for a relayer that covers gas for user transactions up to a allowance specified in Redis to interact with a whitelisted set of contracts.
+# Allowances are on a per account id basis and on signup (account creation in redis and on-chain) an oauth token is required to help with sybil resistance
+
 # Please note this is for reference only and you should be updating the values in the `config.toml` file found in the `pagoda-relayer-rs` directory.
 
 # ip address to run server on, default to localhost
@@ -14,7 +16,9 @@ keys_filenames = ["./account_keys/nomnomnom.testnet.json", "./account_keys/37cb5
 whitelisted_contracts = ["nomnomnom.testnet", "relayer_test0.testnet", "relayer_test1.testnet"]
 # if this is set to false, just call /send_meta_tx or /relay endpoints. All other endpoints are coupled with using redis
 # this needs to be set to true if use_fastauth_features = true
-use_redis = false
+use_redis = true
+# redis url for storing and retrieving allowance for an account_id and seeing if an oauth_token has been used before
+redis_url = "redis://127.0.0.1:6379"
 
 # set use_fastauth_features to true if you're integrating with fastauth -
 # including check if sender id and receiver id are the same AND (AddKey or DeleteKey action) in process_signed_delegate_action fn

--- a/examples/configs/redis.toml
+++ b/examples/configs/redis.toml
@@ -11,6 +11,7 @@ port = 3030
 # replace with the account id of the public key you will use to sign relay transactions - this should match the account_id in your json file
 relayer_account_id = "nomnomnom.testnet"
 # replace with json files containing 3 entries: account_id (should match relayer_account_id), public_key, private_key
+# this is recommended for high throughput use cases to prevent nonce race conditions
 keys_filenames = ["./account_keys/nomnomnom.testnet.json", "./account_keys/37cb5b936de257d014e663663b186e58e4c3c4c9b4c7643e7b89821e789b0b4b.json", "./account_keys/b278b7752b844a0cc88f8dbdb053b860d6283fb353e7a317b3b82efe01396c3e.json", "./account_keys/d7adc371186bc2013ec5de36be27ed9a36022af1112f7c62530baf6042690f61.json", "./account_keys/df86e9701801e30cf0649b2ea43aeacef60e394e076709d4519880d5a9c7bc9e.json", "./account_keys/e4a6dd159d45d4104679e709d29d49a533e5df9467b311c9dbea7fb8f0077335.json"]
 # whitelisted contract ids (receiver_id)
 whitelisted_contracts = ["nomnomnom.testnet", "relayer_test0.testnet", "relayer_test1.testnet"]

--- a/examples/configs/whitelist_senders.toml
+++ b/examples/configs/whitelist_senders.toml
@@ -1,0 +1,46 @@
+# Whitelist Senders config
+# This is a config for a relayer that covers gas for a whitelisted set of users' transactions (identified by whitelisted_delegate_action_receiver_ids) to interact with a whitelisted set of contracts
+
+# Please note this is for reference only and you should be updating the values in the `config.toml` file found in the `pagoda-relayer-rs` directory.
+
+# ip address to run server on, default to localhost
+ip_address = [0, 0, 0, 0]
+# port to expose
+port = 3030
+# replace with the account id of the public key you will use to sign relay transactions - this should match the account_id in your json file
+relayer_account_id = "nomnomnom.testnet"
+# replace with json files containing 3 entries: account_id (should match relayer_account_id), public_key, private_key
+# this is recommended for high throughput use cases to prevent nonce race conditions
+keys_filenames = ["./account_keys/nomnomnom.testnet.json", "./account_keys/37cb5b936de257d014e663663b186e58e4c3c4c9b4c7643e7b89821e789b0b4b.json", "./account_keys/b278b7752b844a0cc88f8dbdb053b860d6283fb353e7a317b3b82efe01396c3e.json", "./account_keys/d7adc371186bc2013ec5de36be27ed9a36022af1112f7c62530baf6042690f61.json", "./account_keys/df86e9701801e30cf0649b2ea43aeacef60e394e076709d4519880d5a9c7bc9e.json", "./account_keys/e4a6dd159d45d4104679e709d29d49a533e5df9467b311c9dbea7fb8f0077335.json"]
+# whitelisted contract ids (receiver_id)
+whitelisted_contracts = ["nomnomnom.testnet", "relayer_test0.testnet", "relayer_test1.testnet"]
+# use this to whitelist sender account ids (delegate_action_receiver_ids)
+use_whitelisted_delegate_action_receiver_ids = true
+# whitelisted sender account ids (delegate_action_receiver_ids)
+whitelisted_delegate_action_receiver_ids = ["relayer_test1.testnet"]
+
+# if this is set to false, just call /send_meta_tx or /relay endpoints. All other endpoints are coupled with using redis
+# this needs to be set to true if use_fastauth_features = true
+use_redis = false
+
+# set use_fastauth_features to true if you're integrating with fastauth -
+# including check if sender id and receiver id are the same AND (AddKey or DeleteKey action) in process_signed_delegate_action fn
+# and you're using shared storage contract
+use_fastauth_features = false
+# you can still use shared storage without fastauth features if you desire,
+# but needs to be set to true if using fastauth or the contract you're sending transactions to requires a storage deposit
+use_shared_storage = false
+
+# Uncoment the network you want to use or add your own
+
+# mainnet
+# rpc_url = "https://rpc.mainnet.near.org"
+# wallet_url = "https://wallet.mainnet.near.org"
+# explorer_transaction_url = "https://explorer.mainnet.near.org/transactions/"
+# rpc_api_key = ""
+
+# testnet
+rpc_url = "https://archival-rpc.testnet.near.org"
+wallet_url = "https://wallet.testnet.near.org"
+explorer_transaction_url = "https://explorer.testnet.near.org/transactions/"
+rpc_api_key = ""

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,6 +96,9 @@ static SHARED_STORAGE_KEYS_FILENAME: Lazy<String> = Lazy::new(|| {
 static WHITELISTED_CONTRACTS: Lazy<Vec<String>> = Lazy::new(|| {
     LOCAL_CONF.get("whitelisted_contracts").unwrap()
 });
+static USE_WHITELISTED_DELEGATE_ACTION_RECEIVER_IDS: Lazy<bool> = Lazy::new(|| {
+    LOCAL_CONF.get("use_whitelisted_delegate_action_receiver_ids").unwrap_or(false)
+});
 static WHITELISTED_DELEGATE_ACTION_RECEIVER_IDS: Lazy<Vec<String>> = Lazy::new(|| {
     LOCAL_CONF.get("whitelisted_delegate_action_receiver_ids").unwrap()
 });
@@ -678,6 +681,12 @@ async fn process_signed_delegate_action(
     let is_whitelisted_da_receiver = WHITELISTED_CONTRACTS.iter().any(
         |s| s == da_receiver_id.as_str()
     );
+    if USE_WHITELISTED_DELEGATE_ACTION_RECEIVER_IDS.clone() && !USE_FASTAUTH_FEATURES.clone() {
+        // check if the receiver_id (delegate action sender_id) if a whitelisted delegate action receiver
+        let is_whitelisted_sender = WHITELISTED_DELEGATE_ACTION_RECEIVER_IDS.iter().any(
+            |s| s == receiver_id.as_str()
+        );
+    }
     if !is_whitelisted_da_receiver && USE_FASTAUTH_FEATURES.clone() {
         // check if sender id and receiver id are the same AND (AddKey or DeleteKey action)
         let non_delegate_action = signed_delegate_action.delegate_action.actions.get(0).ok_or_else(|| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -390,7 +390,7 @@ async fn create_account_atomic(
      */
 
     // check if the oauth_token has already been used and is a key in Redis
-    match redis_fns::get_oauth_token_in_redis(&oauth_token).await {
+    match redis_fns::get_oauth_token_in_redis(oauth_token).await {
         Ok(is_oauth_token_in_redis) => {
             if is_oauth_token_in_redis {
                 let err_msg = format!(
@@ -565,7 +565,7 @@ async fn register_account_and_allowance(
     }
     let redis_result = redis_fns::set_account_and_allowance_in_redis(
         account_id,
-        &allowance_in_gas,
+        allowance_in_gas,
     ).await;
 
     let Ok(_) = redis_result else {
@@ -741,7 +741,7 @@ async fn process_signed_delegate_action(
                 error!("{err_msg}");
                 RelayError {
                     status_code: StatusCode::INTERNAL_SERVER_ERROR,
-                    message: err_msg.into(),
+                    message: err_msg,
                 }
             })?;
 
@@ -822,7 +822,7 @@ async fn process_signed_delegate_action(
                 error!("{err_msg}");
                 RelayError {
                     status_code: StatusCode::INTERNAL_SERVER_ERROR,
-                    message: err_msg.into(),
+                    message: err_msg,
                 }
             })?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -681,11 +681,24 @@ async fn process_signed_delegate_action(
     let is_whitelisted_da_receiver = WHITELISTED_CONTRACTS.iter().any(
         |s| s == da_receiver_id.as_str()
     );
+    // check the sender_id in whitelist if applicable
     if USE_WHITELISTED_DELEGATE_ACTION_RECEIVER_IDS.clone() && !USE_FASTAUTH_FEATURES.clone() {
-        // check if the receiver_id (delegate action sender_id) if a whitelisted delegate action receiver
+        // check if the delegate action receiver_id (account sender_id) if a whitelisted delegate action receiver
         let is_whitelisted_sender = WHITELISTED_DELEGATE_ACTION_RECEIVER_IDS.iter().any(
             |s| s == receiver_id.as_str()
         );
+        if !is_whitelisted_sender {
+            let err_msg = format!(
+                "Delegate Action receiver_id {} or sender_id {} is not whitelisted",
+                da_receiver_id.as_str(),
+                receiver_id.as_str(),
+            );
+            info!("{err_msg}");
+            return Err(RelayError {
+                status_code: StatusCode::BAD_REQUEST,
+                message: err_msg
+            });
+        }
     }
     if !is_whitelisted_da_receiver && USE_FASTAUTH_FEATURES.clone() {
         // check if sender id and receiver id are the same AND (AddKey or DeleteKey action)


### PR DESCRIPTION
https://github.com/near/pagoda-relayer-rs/issues/26

- [x] example config for basic relayer with contract whitelist
- [x] using redis for keeping track of allowances
- [x] fastauth config
- [x] pay with FT config (similar to SWEAT relayer)
- [x] add optional payload check for FT transfer to burn address to config
- [x] whitelisted sender addresses config
- [x] whitelisted sender addresses (delegate_action_receiver_ids) decoupled from fastauth in code
- [x] add capital efficiency note to README