### PR TITLE
Rename endpoint to make API consistent

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -287,7 +287,7 @@ async fn main() {
         .route("/get_allowance", get(get_allowance))
         .route("/update_allowance", post(update_allowance))
         .route("/update_all_allowances", post(update_all_allowances))
-        .route("/register_account_and_allowance", post(register_account_and_allowance))
+        .route("/register_account", post(register_account_and_allowance))
         // See https://docs.rs/tower-http/0.1.1/tower_http/trace/index.html for more details.
         .layer(TraceLayer::new_for_http())
         .layer(cors_layer);


### PR DESCRIPTION
Until we merge FastAuth and OS relayers, let's keep the API consistent. This difference breaks our test env.
After they merge into one repo we can rename it back.