### PR TITLE
 whitelisted senders have unlimited allowance and proper checks for ft_transfer to burn address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2668,6 +2668,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "axum",
+ "base64 0.21.4",
  "bytes",
  "color-eyre",
  "config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.69"
 axum = "0.6.20"
+base64 = "0.21.4"
 bytes = "1.4.0"
 color-eyre = "0.6"
 config = "*"

--- a/config.toml
+++ b/config.toml
@@ -55,17 +55,3 @@ rpc_url = "https://archival-rpc.testnet.near.org"
 wallet_url = "https://wallet.testnet.near.org"
 explorer_transaction_url = "https://explorer.testnet.near.org/transactions/"
 rpc_api_key = ""
-
-# betanet
-# network = "betanet"
-# rpc_url = "https://rpc.betanet.near.org"
-# wallet_url = "https://wallet.betanet.near.org"
-# explorer_transaction_url = "https://explorer.betanet.near.org/transactions/"
-# rpc_api_key = ""
-
-# shardnet
-# network = "shardnet"
-# rpc_url = "https://rpc.shardnet.near.org"
-# wallet_url = "https://wallet.shardnet.near.org"
-# explorer_transaction_url = "https://explorer.shardnet.near.org/transactions/"
-# rpc_api_key = ""


### PR DESCRIPTION
- [x] whitelisted senders have unlimited allowance on startup for fastauth. Fixes: https://github.com/near/pagoda-relayer-rs-fastauth/issues/17 by setting the initial allowance for all whitelisted senders to u64::max.
- [x] proper check for ft_transfer to burn address for pay with FT
- [x] rustfmt