### PR TITLE
Tracing and Flamegraphs/charts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ target/
 # jetbrains ide files
 *.idea
 
+# tracing flamegraph for performance benchmarking
+*.svg
+tracing.folded
+
 # where account and keys are stored
 *.json
 # except for example json file used for testing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2693,6 +2693,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "tracing-flame",
  "tracing-subscriber",
  "url",
  "utoipa",
@@ -3619,6 +3620,17 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
 dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-flame"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bae117ee14789185e129aaee5d93750abe67fdc5a9a62650452bfe4e122a3a9"
+dependencies = [
+ "lazy_static",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,6 @@ color-eyre = "0.6"
 config = "*"
 dirs = "5.0.1"
 linked-hash-map = { version = "0.5", features = ["serde_impl"] }
-mockers = "0.22.0"
-mockall = "0.11.3"
 near-fetch = "0.0.12"
 near-crypto = "0.17.0"
 near-jsonrpc-client = "0.6.0"
@@ -31,8 +29,13 @@ tokio = { version = "~1", features = ["full"] }  # using this version to avoid c
 tower = "0.4.13"
 tower-http = { version = "0.3.5", features = ["trace", "cors"] }
 tracing = "0.1"
+tracing-flame = "0.2.0"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = { version = "2", features = ["serde"] }
 utoipa = { version = "3.5.0", features = ["axum_extras"] }
 utoipa-rapidoc = { version = "0.1.0", features = ["axum"] }
 utoipa-swagger-ui = { version = "3", features = ["axum"] }
+
+[dev-dependencies]
+mockers = "0.22.0"
+mockall = "0.11.3"

--- a/README.md
+++ b/README.md
@@ -116,8 +116,18 @@ NOTE: this is only needed if you intend to use whitelisting, allowances, and oau
 9. Change all the `"account_id"`s of the keyfiles in the relayer directory from the implicit account_id (i.e. `e05185d0de0d6e4897555a386fdd3f48508ad1cdeaebcbd1cac81c72116cc5ab`) to the relayer account_id `your_relayer_account.testnet`
 10. Add the key filenames (i.e. `"e05185d0de0d6e4897555a386fdd3f48508ad1cdeaebcbd1cac81c72116cc5ab.json"`) to the `keys_filenames` list in `config.toml`
 
-## Testing
+## Unit Testing
 1. Run unit tests with `cargo test`
+
+## Performance Testing
+1. Remove the `#[ignore]` attribute above `test_relay_with_load()` testing function and run the test
+2. Flame Tracing https://crates.io/crates/tracing-flame
+   - Set `flametrace_performance = true` in `config.toml` 
+   - run `cargo run`, while sending requests to the endpoints of the functions you want to examine the performance of. 
+   - Stop the execution of the `cargo run` process. 
+   - Install inferno `cargo install inferno` 
+   - Generate the flamegraph from the `tracing.folded` file generated while running the relayer: `cat tracing.folded | inferno-flamegraph > tracing-flamegraph.svg`
+   - Generate a flamechart: `cat tracing.folded | inferno-flamegraph --flamechart > tracing-flamechart.svg`
 
 ## Docker Deployment
 1. Update `config.toml` as per your requirements.

--- a/config.toml
+++ b/config.toml
@@ -41,7 +41,7 @@ use_shared_storage = false
 social_db_contract_id = "v1.social08.testnet"
 
 # flametrace is used for generating flame graphs for performance inspection using the tracing-flame crate https://crates.io/crates/tracing-flame
-flametrace_performance = true
+flametrace_performance = false
 
 # Uncoment the network you want to use or add your own
 

--- a/config.toml
+++ b/config.toml
@@ -51,7 +51,7 @@ social_db_contract_id = "v1.social08.testnet"
 
 # testnet
 network = "testnet"
-rpc_url = "https://archival-rpc.testnet.near.org"
+rpc_url = "https://rpc.testnet.near.org"
 wallet_url = "https://wallet.testnet.near.org"
 explorer_transaction_url = "https://explorer.testnet.near.org/transactions/"
 rpc_api_key = ""

--- a/config.toml
+++ b/config.toml
@@ -40,6 +40,9 @@ use_shared_storage = false
 # reference shared storage contract: https://github.com/NearSocial/social-db/blob/master/contract/src/shared_storage.rs
 social_db_contract_id = "v1.social08.testnet"
 
+# flametrace is used for generating flame graphs for performance inspection using the tracing-flame crate https://crates.io/crates/tracing-flame
+flametrace_performance = true
+
 # Uncoment the network you want to use or add your own
 
 # mainnet

--- a/src/main.rs
+++ b/src/main.rs
@@ -697,7 +697,7 @@ async fn process_signed_delegate_action(
     let is_whitelisted_da_receiver = WHITELISTED_CONTRACTS
         .iter()
         .any(|s| s == da_receiver_id.as_str());
-    if !is_whitelisted_da_receiver {
+    if !USE_FASTAUTH_FEATURES.clone() && !is_whitelisted_da_receiver {
         let err_msg = format!(
             "Delegate Action receiver_id {} is not whitelisted",
             da_receiver_id.as_str(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ use axum::{
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD as BASE64_ENGINE, Engine as _};
 #[cfg(test)]
 use bytes::BytesMut;
-use config::{Config, File};
+use config::{Config, File as ConfigFile};
 use near_crypto::InMemorySigner;
 #[cfg(test)]
 use near_crypto::{KeyType, PublicKey, Signature};
@@ -46,13 +46,10 @@ use std::net::SocketAddr;
 use std::str::FromStr;
 use std::string::ToString;
 use std::{fmt, path::Path};
-use std::{fs::File as StdFsFile, io::BufWriter};
 use tower_http::trace::TraceLayer;
 use tracing::{debug, error, info, instrument, warn};
 use tracing_flame::FlameLayer;
-use tracing_subscriber::{
-    layer::SubscriberExt, prelude::*, registry::Registry, util::SubscriberInitExt,
-};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use utoipa::{OpenApi, ToSchema};
 use utoipa_rapidoc::RapiDoc;
 use utoipa_swagger_ui::SwaggerUi;
@@ -72,7 +69,7 @@ const YN_TO_GAS: u128 = 1_000_000_000;
 // load config from toml and setup json rpc client
 static LOCAL_CONF: Lazy<Config> = Lazy::new(|| {
     Config::builder()
-        .add_source(File::with_name("config.toml"))
+        .add_source(ConfigFile::with_name("config.toml"))
         .build()
         .unwrap()
 });


### PR DESCRIPTION
To help identify performance bottlenecks, such as the [one identified](https://github.com/near/pagoda-relayer-rs/issues/40) with `/create_account_atomic` when deployed, more tracing features have been added. We can now see the time taken for each request to send a response:
```
2023-11-15T21:15:30.881115Z DEBUG request{method=GET uri=/get_allowance version=HTTP/1.1}: tower_http::trace::on_response: finished processing request latency=27 ms status=200
2023-11-15T21:16:00.230494Z DEBUG request{method=POST uri=/send_meta_tx version=HTTP/1.1}: tower_http::trace::on_response: finished processing request latency=3078 ms status=500
2023-11-15T21:16:32.513769Z DEBUG request{method=POST uri=/create_account_atomic version=HTTP/1.1}: tower_http::trace::on_response: finished processing request latency=2235 ms status=500
```

- [x]  add tracing `#[instrument]` attribute to each endpoint function and `process_signed_delegate_action` which enables the request latency in the tracing logs
- [x] support for flamegraph and flamechart generation using the https://crates.io/crates/tracing-flame crate
- [x] updated README with performance testing instrucitons
- [x] changes from https://github.com/near/pagoda-relayer-rs/pull/46 also included