### PR TITLE
CLEANUP: update dependencies, async, nopoll txns, slow retry for fastauth create account, feature_flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,8 +361,18 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
 dependencies = [
- "borsh-derive",
+ "borsh-derive 0.10.3",
  "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "borsh"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9897ef0f1bd2362169de6d7e436ea2237dc1085d7d1e4db75f4be34d86f309d1"
+dependencies = [
+ "borsh-derive 1.2.1",
+ "cfg_aliases",
 ]
 
 [[package]]
@@ -373,9 +383,23 @@ checksum = "0754613691538d51f329cce9af41d7b7ca150bc973056f1156611489475f54f7"
 dependencies = [
  "borsh-derive-internal",
  "borsh-schema-derive-internal",
- "proc-macro-crate",
+ "proc-macro-crate 0.1.5",
  "proc-macro2",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478b41ff04256c5c8330f3dfdaaae2a5cc976a8e75088bafa4625b0d0208de8c"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate 2.0.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+ "syn_derive",
 ]
 
 [[package]]
@@ -457,6 +481,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chrono"
@@ -833,6 +863,12 @@ name = "dtoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "545b22097d44f8a9581187cdf93de7a71e4722bf51200cfaba810865b49a495d"
 
 [[package]]
 name = "easy-ext"
@@ -1642,7 +1678,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc0cb40869cab7f5232f934f45db35bffe0f2d2a7cb0cd0346202fbe4ebf2dd7"
 dependencies = [
- "borsh",
+ "borsh 0.10.3",
  "serde",
 ]
 
@@ -1687,7 +1723,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff6b382b626e7e0cd372d027c6672ac97b4b6ee6114288c9e58d8180b935d315"
 dependencies = [
  "blake2",
- "borsh",
+ "borsh 0.10.3",
  "bs58",
  "c2-chacha",
  "curve25519-dalek",
@@ -1709,15 +1745,17 @@ dependencies = [
 
 [[package]]
 name = "near-fetch"
-version = "0.0.12"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d227650df31a89e5bd256f7a9b5ae85f6f9b855f7114b2a4e935d15372d77cab"
+checksum = "b781c0a57944d4cea8c7586e98e76f08b2e107d23338eeb9aca88213b2cbcd98"
 dependencies = [
  "near-account-id",
  "near-crypto",
+ "near-gas",
  "near-jsonrpc-client",
  "near-jsonrpc-primitives",
  "near-primitives",
+ "near-token",
  "serde",
  "serde_json",
  "thiserror",
@@ -1735,12 +1773,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "near-gas"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14e75c875026229902d065e4435804497337b631ec69ba746b102954273e9ad1"
+dependencies = [
+ "borsh 1.2.1",
+ "schemars",
+ "serde",
+]
+
+[[package]]
 name = "near-jsonrpc-client"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "118f44c02ad211db805c1370ad3ff26576af6ff554093c9fece1b835d29d233a"
 dependencies = [
- "borsh",
+ "borsh 0.10.3",
  "lazy_static",
  "log",
  "near-chain-configs",
@@ -1802,7 +1851,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f7051aaf199adc4d068620fca6d5f70f906a1540d03a8bb3701271f8881835"
 dependencies = [
  "arbitrary",
- "borsh",
+ "borsh 0.10.3",
  "bytesize",
  "cfg-if",
  "chrono",
@@ -1840,7 +1889,7 @@ checksum = "775fec19ef51a341abdbf792a9dda5b4cb89f488f681b2fd689b9321d24db47b"
 dependencies = [
  "arbitrary",
  "base64 0.21.4",
- "borsh",
+ "borsh 0.10.3",
  "bs58",
  "derive_more",
  "enum-map",
@@ -1884,6 +1933,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6540152fba5e96fe5d575b79e8cd244cf2add747bb01362426bdc069bc3a23bc"
 
 [[package]]
+name = "near-token"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b68f3f8a2409f72b43efdbeff8e820b81e70824c49fee8572979d789d1683fb"
+
+[[package]]
 name = "near-units"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1921,7 +1976,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec545d1bede0579e7c15dd2dce9b998dc975c52f2165702ff40bec7ff69728bb"
 dependencies = [
- "borsh",
+ "borsh 0.10.3",
  "near-account-id",
  "near-rpc-error-macro",
  "serde",
@@ -2340,6 +2395,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
  "toml",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97dc5fea232fc28d2f597b37c4876b348a40e33f3b02cc975c8d006d78d94b1a"
+dependencies = [
+ "toml_datetime",
+ "toml_edit",
 ]
 
 [[package]]
@@ -2913,6 +2978,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45a28f4c49489add4ce10783f7911893516f15afe45d015608d41faca6bc4d29"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c767fd6fa65d9ccf9cf026122c1b555f2ef9a4f0cea69da4d7dbc3e258d30967"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2994,6 +3083,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.37",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3259,6 +3359,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn_derive"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1329189c02ff984e9736652b1631330da25eaa6bc639089ed4915d25446cbe7b"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3473,6 +3585,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+
+[[package]]
+name = "toml_edit"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
+dependencies = [
+ "indexmap 2.0.0",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -4085,6 +4214,15 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "winnow"
+version = "0.5.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c830786f7720c2fd27a1a0e27a709dbd3c4d009b56d098fc742d4f4eab91fe2"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,8 @@ utoipa-swagger-ui = { version = "3", features = ["axum"] }
 [dev-dependencies]
 mockers = "0.22.0"
 mockall = "0.11.3"
+
+[features]
+default = []
+fastauth_features = []
+shared_storage = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ color-eyre = "0.6"
 config = "*"
 dirs = "5.0.1"
 linked-hash-map = { version = "0.5", features = ["serde_impl"] }
-near-fetch = "0.0.12"
+near-fetch = "0.1.2"
 near-crypto = "0.17.0"
 near-jsonrpc-client = "0.6.0"
 near-jsonrpc-primitives = "0.17.0"

--- a/README.md
+++ b/README.md
@@ -24,23 +24,23 @@ These features can be mixed and matched "à la carte". Use of one feature does n
 NOTE: If integrating with fastauth make sure to enable feature flags: `cargo build --features fastauth_features,shared_storage`. If using shared storage, make sure to enable feature flags: `cargo build --features shared_storage`
 
 
-1. Cover the gas costs of end users while allowing them to maintain custody of their funds and approve transactions (`/relay`, `/send_meta_tx`)
+1. Cover the gas costs of end users while allowing them to maintain custody of their funds and approve transactions (`/relay`, `/send_meta_tx`, `/send_meta_tx_async`, `/send_meta_tx_nopoll`)
 2. Only pay for users interacting with certain contracts by whitelisting contracts addresses (`whitelisted_contracts` in `config.toml`) 
 3. Specify gas cost allowances for all accounts (`/update_all_allowances`) or on a per-user account basis (`/create_account_atomic`, `/register_account`, `/update_allowance`) and keep track of allowances (`/get_allowance`)
 4. Specify the accounts for which the relayer will cover gas fees (`whitelisted_delegate_action_receiver_ids` in `config.toml`)
 5. Only allow users to register if they have a unique Oauth Token (`/create_account_atomic`, `/register_account`)
 6. Relayer Key Rotation: `keys_filenames` in `config.toml`
 7. Integrate with [Fastauth SDK](https://docs.near.org/tools/fastauth-sdk). See `/examples/configs/fastauth.toml`
+8. Mix and Match config options - see `examples/configs`
 
 ### Features - COMING SOON
 1. Allow users to pay for gas fees using Fungible Tokens they hold. This can be implemented by either:
    1. Swapping the FT for NEAR using a DEX like [Ref finance](https://app.ref.finance/) OR
    2. Sending the FT to a burn address that is verified by the relayer and the relayer covers the equivalent amount of gas in NEAR
 2. Cover storage deposit costs by deploying a storage contract
-3. Configure via to config use relayer without storage contract
-4. automated relayer funds "top up" service
-5. Put transactions in a queue to minimize network congestion - expected early-mid 2024
-6. Multichain relayers - expected early-mid 2024
+3. automated relayer funds "top up" service
+4. Put transactions in a queue to minimize network congestion - expected early-mid 2024
+5. Multichain relayers - expected early-mid 2024
 
 ## API Spec <a id="api_spc"></a>
 For more details on the following endpoint and to try them out, please [setup your local dev env](#basic_setup).
@@ -85,6 +85,8 @@ with
 For more extensive testing, especially when you've deployed the relayer to multiple environments, it is recommended that you use Postman or some other api testing service.
 - POST `/relay`
 - POST `/send_meta_tx`
+- POST `/send_meta_tx_async`
+- POST `/send_meta_tx_nopoll`
 - GET `/get_allowance`
 - POST `/update_allowance`
 - POST `/update_all_allowances`

--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ The `SignedTransaction` is then sent to the network via RPC call and the result 
 6. Capital Efficiency: Without relayer if your business has 1M users they would have to be allocated 0.25 NEAR to cover their gas costs totalling 250k NEAR. However, only ~10% of the users would actually use the full allowance and a large amount of the 250k NEAR is just sitting there unused. So using the relayer, you can allocate 50k NEAR as a global pool of capital for your users, which can refilled on an as needed basis.
 
 ## Features 
-NOTE: These features can be mixed and matched "à la carte". Use of one feature does not preclude the use of any other feature unless specified. See the `/examples` directory for example configs corresponding to different use cases.
+These features can be mixed and matched "à la carte". Use of one feature does not preclude the use of any other feature unless specified. See the `/examples` directory for example configs corresponding to different use cases.
+
+NOTE: If integrating with fastauth make sure to enable feature flags: `cargo build --features fastauth_features,shared_storage`. If using shared storage, make sure to enable feature flags: `cargo build --features shared_storage`
+
+
 1. Cover the gas costs of end users while allowing them to maintain custody of their funds and approve transactions (`/relay`, `/send_meta_tx`)
 2. Only pay for users interacting with certain contracts by whitelisting contracts addresses (`whitelisted_contracts` in `config.toml`) 
 3. Specify gas cost allowances for all accounts (`/update_all_allowances`) or on a per-user account basis (`/create_account_atomic`, `/register_account`, `/update_allowance`) and keep track of allowances (`/get_allowance`)
@@ -93,7 +97,9 @@ For more extensive testing, especially when you've deployed the relayer to multi
 3. With the account from step 2, create a json file in this directory in the format `{"account_id":"example.testnet","public_key":"ed25519:98GtfFzez3opomVpwa7i4m3nptHtc7Ha514XHMWszLtQ","private_key":"ed25519:YWuyKVQHE3rJQYRC3pRGV56o1qEtA1PnMYPDEtroc5kX4A4mWrJwF7XkzGe7JWNMABbtY4XFDBJEzgLyfPkwpzC"}` using a [Full Access Key](https://docs.near.org/concepts/basics/accounts/access-keys#key-types) from an account that has enough NEAR to cover the gas costs of transactions your server will be relaying. Usually, this will be a copy of the json file found in the `.near-credentials` directory. 
 4. Update values in `config.toml`
 5. Open up the `port` from `config.toml` in your machine's network settings
-6. Run the server using `cargo run`. To run with logs (tracing) enabled run `RUST_LOG=tower_http=debug cargo run`
+6. Run the server using `cargo run`. 
+7. (OPTIONAL) To run with logs (tracing) enabled run `RUST_LOG=tower_http=debug cargo run`
+8. (OPTIONAL) If integrating with fastauth make sure to enable feature flags: `cargo build --features fastauth_features,shared_storage`. If using shared storage, make sure to enable feature flags: `cargo build --features shared_storage`
 
 ## Redis Setup - OPTIONAL 
 NOTE: this is only needed if you intend to use whitelisting, allowances, and oauth functionality

--- a/examples/configs/fastauth.toml
+++ b/examples/configs/fastauth.toml
@@ -7,6 +7,7 @@
 
 # Please note this is for reference only and you should be updating the values in the `config.toml` file found in the `pagoda-relayer-rs` directory.
 
+# NOTE: make sure to enable feature flags: `cargo build --features fastauth_features,shared_storage`
 
 # ip address to run server on, default to localhost
 ip_address = [0, 0, 0, 0]

--- a/examples/configs/shared_storage.toml
+++ b/examples/configs/shared_storage.toml
@@ -3,6 +3,8 @@
 
 # Please note this is for reference only and you should be updating the values in the `config.toml` file found in the `pagoda-relayer-rs` directory.
 
+# NOTE: make sure to enable feature flag: `cargo build --features shared_storage`
+
 # ip address to run server on, default to localhost
 ip_address = [0, 0, 0, 0]
 # port to expose

--- a/src/main.rs
+++ b/src/main.rs
@@ -889,8 +889,7 @@ async fn process_signed_delegate_action_noretry_async(
 
 async fn process_signed_delegate_action_inner<F>(
     signed_delegate_action: SignedDelegateAction,
-    #[allow(unused_variables)] // makes compiler happy - used by Future
-    f: impl Fn(AccountId, Vec<Action>) -> F,
+    _f: impl Fn(AccountId, Vec<Action>) -> F,
 ) -> Result<String, RelayError>
 where
     F: Future<Output = Result<TransactionResult, String>>,

--- a/src/rpc_conf.rs
+++ b/src/rpc_conf.rs
@@ -67,11 +67,15 @@ pub struct NetworkConfig {
 
 impl NetworkConfig {
     pub fn rpc_client(&self) -> near_fetch::Client {
+        near_fetch::Client::from_client(self.raw_rpc_client())
+    }
+
+    pub fn raw_rpc_client(&self) -> near_jsonrpc_client::JsonRpcClient {
         let mut json_rpc_client =
             near_jsonrpc_client::JsonRpcClient::connect(self.rpc_url.as_ref());
         if let Some(rpc_api_key) = &self.rpc_api_key {
             json_rpc_client = json_rpc_client.header(rpc_api_key.0.clone());
         };
-        near_fetch::Client::from_client(json_rpc_client)
+        json_rpc_client
     }
 }

--- a/src/shared_storage.rs
+++ b/src/shared_storage.rs
@@ -131,17 +131,6 @@ impl SharedStoragePoolManager {
         Ok(())
     }
 
-    // #[allow(dead_code)]
-    // async fn get_account_storage(&self) -> anyhow::Result<Option<StorageView>> {
-    //     self.rpc_client
-    //         .view(&self.pool_contract_id, "get_account_storage")
-    //         .args_json(serde_json::json!({
-    //             "account_id": self.pool_owner_id.clone(),
-    //         }))
-    //         .await
-    //         .map_err(Into::into)
-    // }
-
     async fn get_shared_storage_pool(&self) -> anyhow::Result<Option<SharedStoragePool>> {
         let res = self
             .rpc_client

--- a/src/shared_storage.rs
+++ b/src/shared_storage.rs
@@ -1,5 +1,6 @@
-use anyhow::Context;
+use anyhow::{anyhow, Context};
 use near_crypto::InMemorySigner;
+use near_fetch::Client;
 use near_primitives::transaction::{Action, FunctionCallAction};
 use near_primitives::types::{AccountId, Balance, Gas, StorageUsage};
 use serde::Deserialize;
@@ -29,7 +30,7 @@ const fn bytes_per_amount(amount: Balance) -> u64 {
 /// near social.
 pub struct SharedStoragePoolManager {
     signer: InMemorySigner,
-    rpc_client: &'static near_fetch::Client,
+    rpc_client: &'static Client,
     pool_contract_id: AccountId,
     pool_owner_id: AccountId,
 }
@@ -37,7 +38,7 @@ pub struct SharedStoragePoolManager {
 impl SharedStoragePoolManager {
     pub fn new(
         signer: InMemorySigner,
-        rpc_client: &'static near_fetch::Client,
+        rpc_client: &'static Client,
         pool_contract_id: AccountId,
         pool_owner_id: AccountId,
     ) -> Self {
@@ -64,7 +65,7 @@ impl SharedStoragePoolManager {
     }
 
     /// Allocate default number of bytes per account in the shared pool.
-    pub async fn allocate_default(&self, id: &AccountId) -> anyhow::Result<()> {
+    pub async fn allocate_default(&self, id: AccountId) -> anyhow::Result<()> {
         // NOTE: Allocating default amount of bytes is idempotent since calling into
         // share_storage will only set the max bytes and not increase it. Thus calling
         // with the same amount of bytes will not increase the amount of bytes allocated.
@@ -72,7 +73,7 @@ impl SharedStoragePoolManager {
     }
 
     /// Allocate a set number of bytes for an account in the shared pool.
-    pub async fn allocate(&self, id: &AccountId, max_bytes: u64) -> anyhow::Result<()> {
+    pub async fn allocate(&self, id: AccountId, max_bytes: u64) -> anyhow::Result<()> {
         // TODO: figure out why get_account_storage doesn't work for an account like:
         // `social-storage.pagodaplatform.near`
         self.share_storage(id, max_bytes).await?;
@@ -83,7 +84,7 @@ impl SharedStoragePoolManager {
         let actions = vec![Action::FunctionCall(FunctionCallAction {
             method_name: "shared_storage_pool_deposit".into(),
             args: serde_json::json!({
-                "owner_id": self.pool_owner_id,
+                "owner_id": self.pool_owner_id.clone(),
             })
             .to_string()
             .into_bytes(),
@@ -97,7 +98,7 @@ impl SharedStoragePoolManager {
         Ok(())
     }
 
-    async fn share_storage(&self, id: &AccountId, max_bytes: StorageUsage) -> anyhow::Result<()> {
+    async fn share_storage(&self, id: AccountId, max_bytes: StorageUsage) -> anyhow::Result<()> {
         let actions = vec![Action::FunctionCall(FunctionCallAction {
             method_name: "share_storage".into(),
             args: serde_json::json!({
@@ -116,36 +117,34 @@ impl SharedStoragePoolManager {
         Ok(())
     }
 
-    #[allow(dead_code)]
-    async fn get_account_storage(&self) -> anyhow::Result<Option<StorageView>> {
-        self.rpc_client
-            .view(
-                &self.pool_contract_id,
-                "get_account_storage",
-                serde_json::json!({
-                    "account_id": self.pool_owner_id,
-                }),
-            )
-            .await
-            .map_err(Into::into)
-    }
+    // #[allow(dead_code)]
+    // async fn get_account_storage(&self) -> anyhow::Result<Option<StorageView>> {
+    //     self.rpc_client
+    //         .view(&self.pool_contract_id, "get_account_storage")
+    //         .args_json(serde_json::json!({
+    //             "account_id": self.pool_owner_id.clone(),
+    //         }))
+    //         .await
+    //         .map_err(Into::into)
+    // }
 
     async fn get_shared_storage_pool(&self) -> anyhow::Result<Option<SharedStoragePool>> {
-        self.rpc_client
-            .view(
-                &self.pool_contract_id,
-                "get_shared_storage_pool",
-                serde_json::json!({
-                    "owner_id": self.pool_owner_id,
-                }),
-            )
-            .await
-            .map_err(Into::into)
+        let res = self
+            .rpc_client
+            .view(&self.pool_contract_id, "get_shared_storage_pool")
+            .args_json(serde_json::json!({
+                "owner_id": self.pool_owner_id.clone(),
+            }))
+            .await;
+        match res {
+            Ok(res) => serde_json::from_slice(&res.result).map_err(|e| anyhow!(e)),
+            Err(e) => Err(anyhow!(e)),
+        }
     }
 }
 
 /// Taken directly from near.social contract to deserialize into when calling
-/// `get_account_storage`.
+/// get_account_storage.
 #[derive(Debug, Deserialize)]
 pub struct StorageView {
     pub used_bytes: StorageUsage,
@@ -153,7 +152,7 @@ pub struct StorageView {
 }
 
 /// Taken directly from near.social contract to deserialize into when calling
-/// `get_shared_storage_pool`
+/// get_shared_storage_pool
 // JSON deserialization trick. no need to understand what actual structure is.
 #[derive(Debug, Deserialize)]
 pub struct SharedStoragePool(serde_json::Map<String, serde_json::Value>);

--- a/src/shared_storage.rs
+++ b/src/shared_storage.rs
@@ -1,26 +1,38 @@
+#[cfg(feature = "shared_storage")]
 use anyhow::{anyhow, Context};
+#[cfg(feature = "shared_storage")]
 use near_crypto::InMemorySigner;
+#[cfg(feature = "shared_storage")]
 use near_fetch::Client;
+#[cfg(feature = "shared_storage")]
 use near_primitives::transaction::{Action, FunctionCallAction};
+#[cfg(feature = "shared_storage")]
 use near_primitives::types::{AccountId, Balance, Gas, StorageUsage};
+#[cfg(feature = "shared_storage")]
 use serde::Deserialize;
+#[cfg(feature = "shared_storage")]
 use tracing::debug;
 
 /// Gas for transactions to shared storage pool.
+#[cfg(feature = "shared_storage")]
 const MAX_GAS: Gas = 300_000_000_000_000;
 
 /// Constant set at 1E19 yoctoNEAR per byte on chain.
 // TODO: This is set for reference on chain, and can change with future protocol changes,
 // so best to retrieve chain config later.
+#[cfg(feature = "shared_storage")]
 const STORAGE_PRICE_PER_BYTE: Balance = 10_000_000_000_000_000_000;
 
 /// Minimum deposit required to use the shared storage pool. This will also be the amount
 /// to reup the pool every time. This is set to the minimum that social DB wants of 100N.
+#[cfg(feature = "shared_storage")]
 const STORAGE_UP_DEPOSIT: Balance = 100 * 10u128.pow(24);
 
 /// Default amount of bytes allocated per account. This will not change and is set to 50KB.
+#[cfg(feature = "shared_storage")]
 const BYTES_ALLOCATED_PER_ACCOUNT: u64 = bytes_per_amount(near_units::parse_near!("0.5 N"));
 
+#[cfg(feature = "shared_storage")]
 const fn bytes_per_amount(amount: Balance) -> u64 {
     (amount / STORAGE_PRICE_PER_BYTE) as u64
 }
@@ -28,6 +40,7 @@ const fn bytes_per_amount(amount: Balance) -> u64 {
 /// Shared storage pool manager is used to manage the storage pools in a contract
 /// that implements the shared storage pool interface. This includes social DB for
 /// near social.
+#[cfg(feature = "shared_storage")]
 pub struct SharedStoragePoolManager {
     signer: InMemorySigner,
     rpc_client: &'static Client,
@@ -35,6 +48,7 @@ pub struct SharedStoragePoolManager {
     pool_owner_id: AccountId,
 }
 
+#[cfg(feature = "shared_storage")]
 impl SharedStoragePoolManager {
     pub fn new(
         signer: InMemorySigner,
@@ -145,6 +159,7 @@ impl SharedStoragePoolManager {
 
 /// Taken directly from near.social contract to deserialize into when calling
 /// get_account_storage.
+#[cfg(feature = "shared_storage")]
 #[derive(Debug, Deserialize)]
 pub struct StorageView {
     pub used_bytes: StorageUsage,
@@ -154,5 +169,6 @@ pub struct StorageView {
 /// Taken directly from near.social contract to deserialize into when calling
 /// get_shared_storage_pool
 // JSON deserialization trick. no need to understand what actual structure is.
+#[cfg(feature = "shared_storage")]
 #[derive(Debug, Deserialize)]
 pub struct SharedStoragePool(serde_json::Map<String, serde_json::Value>);


### PR DESCRIPTION
- [x] updated near-fetch version and shared storage logic
- [x] feature flags for fastauth and shared storage
- [x] `process_signed_delegate_action_noretry_async` fn used by new endpoints `/send_meta_tx_async`, `/send_meta_tx_nopoll` - for high throughput transactions
- [x] use blocking, very slow retry only for create-account transactions for fastauth


includes selective updates from fastauth relayer changes: https://github.com/near/pagoda-relayer-rs-fastauth/pull/56, https://github.com/near/pagoda-relayer-rs-fastauth/pull/60, https://github.com/near/pagoda-relayer-rs-fastauth/pull/61/