### PR TITLE
feat(ci): Optimize GitHub Action

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "develop" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "develop" ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,41 +10,32 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-
+  test:
+    name: Run Tests
     runs-on: ubuntu-latest
-
+    services:
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
     steps:
-    - uses: actions/checkout@v3
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
-    - name: rust-clippy-check
-      # You may pin to the exact commit or the version.
-      # uses: actions-rs/clippy-check@b5b5f21f4797c02da247df37026fcd0a5024aa4d
-      uses: actions-rs/clippy-check@v1.0.7
-      with:
-        # GitHub token
-        token: ${{ secrets.GITHUB_TOKEN }}
-        # Toolchain to use (without the `+` sign, ex. `nightly`)
-        # toolchain: # optional
-        # Arguments for the cargo command
-        # args: # optional
-        # Use cross instead of cargo
-        # use-cross: # optional
-        # Display name of the created GitHub check. Must be unique across several actions-rs/clippy-check invocations.
-        # name: # optional, default is clippy
-    - name: Setup Rust Toolchain for GitHub CI
-      # You may pin to the exact commit or the version.
-      # uses: actions-rust-lang/setup-rust-toolchain@64fef3b54176f6c03745153e9aae267bf88cbc0f
-      uses: actions-rust-lang/setup-rust-toolchain@v1.4.3
-      # with:
-        # Rust toolchain specification -- see https://rust-lang.github.io/rustup/concepts/toolchains.html#toolchain-specification
-        # toolchain: # optional, default is stable
-        # Target triple to install for this toolchain
-        # target: # optional
-        # Comma-separated list of components to be additionally installed
-        # components: # optional
-        # Automatically configure Rust cache
-        # cache: # optional, default is true
+      - uses: actions/checkout@v4
+      - name: Run tests
+        run: cargo test --all-targets --all-features
+
+  linting:
+    name: Format and Clippy Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check formatting
+        continue-on-error: true
+        run: |
+          cargo fmt --check
+
+      - name: Run Clippy
+        uses: actions-rs/clippy-check@v1.0.7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-targets --all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,18 +24,18 @@ jobs:
         run: cargo test --all-targets --all-features
 
   linting:
-    name: Format and Clippy Check
+    name: Linting
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       - name: Check formatting
-        continue-on-error: true
         run: |
           cargo fmt --check
 
       - name: Run Clippy
+        if: always()
         uses: actions-rs/clippy-check@v1.0.7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-targets --all-features
+          args: --all-targets --all-features -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,6 +20,14 @@ jobs:
           - 6379:6379
     steps:
       - uses: actions/checkout@v4
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Run tests
         run: cargo test --all-targets --all-features
 
@@ -28,6 +36,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Check formatting
         run: |
@@ -35,7 +51,4 @@ jobs:
 
       - name: Run Clippy
         if: always()
-        uses: actions-rs/clippy-check@v1.0.7
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-targets --all-features -- -D warnings
+        run: cargo clippy --all-targets --all-features -- -D warnings

--- a/src/main.rs
+++ b/src/main.rs
@@ -317,7 +317,7 @@ fn create_shared_storage_pool(
     SharedStoragePoolManager::new(
         signer,
         Arc::clone(&rpc_client),
-        config.social_db_contract_id.clone(),
+        config.social_db_contract_id.parse().unwrap(),
         config.shared_storage_account_id.parse().unwrap(),
     )
 }


### PR DESCRIPTION
* Runs all tests, including those that require Redis
* Runs both formatting and linting with clippy
    * I had to replace the Action for clippy since it's deprecated and doesn't even work now
* Build-time caching for faster checks and tests
* Split out tests and linting into their own actions and run in parallel
* Ensure tests run on every PR (since `develop` is the default target branch)
* Fix compilation error in "unused" code (off by default due to feature flag)

Note that the `test_send_meta_tx` has been ignored. I tried running it locally but it doesn't work. Out of scope for this PR to fix it.

You can see that the checks [correctly fail](https://github.com/near/pagoda-relayer-rs/pull/71) formatting and linting issues! Even better news is that the tests are finally being run, and they pass.