### PR TITLE
chore: Cleanup old keys

### DIFF
--- a/37cb5b936de257d014e663663b186e58e4c3c4c9b4c7643e7b89821e789b0b4b.json
+++ b/37cb5b936de257d014e663663b186e58e4c3c4c9b4c7643e7b89821e789b0b4b.json
@@ -1,1 +1,0 @@
-{"account_id":"nomnomnom.testnet","public_key":"ed25519:4koGtebBBTbpRFqiGvJh6Nvjt49Hxfr2q9iGfwLhxD1c","private_key":"ed25519:5mzHaF7XYbXc1ms5hnaXUbvWBCqCEhd3mBiCdXAW7LWZ6aUkeHr3DWEVfQux4t3DPqqF65SAwxPwp85R3J1t5N6e"}

--- a/b278b7752b844a0cc88f8dbdb053b860d6283fb353e7a317b3b82efe01396c3e.json
+++ b/b278b7752b844a0cc88f8dbdb053b860d6283fb353e7a317b3b82efe01396c3e.json
@@ -1,1 +1,0 @@
-{"account_id":"nomnomnom.testnet","public_key":"ed25519:D1gLHsjVSD9GkSfoUZKbK21ijrFGKqWqVLXyrvk8iJ77","private_key":"ed25519:52sewXpbYCmGMEutSVMRrqKyk8zeAdTpGZAt1EbqwHX9bhJ8emRhUdgK39xT3gNnQMTaWRNy8UHtZmiRxnC5H4GD"}

--- a/d7adc371186bc2013ec5de36be27ed9a36022af1112f7c62530baf6042690f61.json
+++ b/d7adc371186bc2013ec5de36be27ed9a36022af1112f7c62530baf6042690f61.json
@@ -1,1 +1,0 @@
-{"account_id":"nomnomnom.testnet","public_key":"ed25519:FWvLGpjKtdsei1x4mDFoT8Dx6V2qdRTzCZLytjWXqkuE","private_key":"ed25519:46b8HL5aMDxxm86K2exAHLJVFAmK5oeDDy68LqCSn7prCuhKuzvpJr6UhKnGcBVRTbrZa5qp29bo7fZiVQbGMkQG"}

--- a/df86e9701801e30cf0649b2ea43aeacef60e394e076709d4519880d5a9c7bc9e.json
+++ b/df86e9701801e30cf0649b2ea43aeacef60e394e076709d4519880d5a9c7bc9e.json
@@ -1,1 +1,0 @@
-{"account_id":"nomnomnom.testnet","public_key":"ed25519:G3ZEXxMAGJfCwV6qX2FLnxbro18i8nWmdVA5RYpdx4vy","private_key":"ed25519:2U7qJmmFchWpaJuFUpvwPs9AyMNbgm2aBtpLS58uL6mvz4v73oqjghhuKEzDDTXFz37H5FBfvJqSUnXVmzb45CWq"}

--- a/e4a6dd159d45d4104679e709d29d49a533e5df9467b311c9dbea7fb8f0077335.json
+++ b/e4a6dd159d45d4104679e709d29d49a533e5df9467b311c9dbea7fb8f0077335.json
@@ -1,1 +1,0 @@
-{"account_id":"nomnomnom.testnet","public_key":"ed25519:GPZXkJRYrs7axV9DMA9agZQuXaApStPExd3sGvkPuL7E","private_key":"ed25519:3UdU7PjVCKWrymsp6UoCfeNKCRyDUFPLAEWdkFPfvKQ81x8uM19ncY8qirvrR8b38RCoU4R35sK1YPvWQ8LNkEn8"}


### PR DESCRIPTION
All the keys are now in `account_keys`, so these are no longer necessary