### PR TITLE
chore: Align Rust versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.74 AS builder
+FROM rust:1.77 AS builder
 WORKDIR /usr/src/relayer
 COPY Cargo.toml Cargo.lock ./
 COPY src ./src


### PR DESCRIPTION
* The GitHub Action recently updated the Rust version to 1.77 and the linter started complaining (fixed in #82)
* Align the Docker image with the latest stable version of Rust (1.77)