### PR TITLE
DelegateActionSenderDoesNotMatchTxReceiver error fix

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1613,7 +1613,8 @@ where
         validate_signed_delegate_action(state, &signed_delegate_action);
     validation_result?;
 
-    let receiver_id: &AccountId = &signed_delegate_action.delegate_action.receiver_id;
+    // the receiver of the txn is the sender of the signed delegate action
+    let receiver_id: &AccountId = &signed_delegate_action.delegate_action.sender_id;
     let actions: Vec<Action> = vec![Action::Delegate(signed_delegate_action.clone())];
     let txn_hash: CryptoHash = state
         .rpc_client
@@ -1650,8 +1651,8 @@ where
         validate_signed_delegate_action(state, &signed_delegate_action);
     validation_result?;
 
-    let signer_account_id: &AccountId = &signed_delegate_action.delegate_action.sender_id;
-    let receiver_id: &AccountId = &signed_delegate_action.delegate_action.receiver_id;
+    // the receiver of the txn is the sender of the signed delegate action
+    let receiver_id: &AccountId = &signed_delegate_action.delegate_action.sender_id;
     let actions: Vec<Action> = vec![Action::Delegate(signed_delegate_action.clone())];
 
     // gas allowance redis specific validation
@@ -1704,7 +1705,7 @@ where
         debug!("total gas burnt in yN: {}", gas_used_in_yn);
         let new_allowance = update_remaining_allowance(
             &state.redis_pool.clone().unwrap(),
-            signer_account_id,
+            receiver_id,
             gas_used_in_yn,
             remaining_allowance,
         )
@@ -1717,7 +1718,7 @@ where
                 message: err_msg,
             }
         })?;
-        info!("Updated remaining allowance for account {signer_account_id}: {new_allowance}",);
+        info!("Updated remaining allowance for account {receiver_id}: {new_allowance}",);
 
         if let FinalExecutionStatus::Failure(_) = status {
             error!("Error message: \n{status_msg:?}");

--- a/src/shared_storage.rs
+++ b/src/shared_storage.rs
@@ -154,4 +154,5 @@ pub struct StorageView {
 /// get_shared_storage_pool
 // JSON deserialization trick. no need to understand what actual structure is.
 #[derive(Debug, Deserialize)]
+#[allow(dead_code)]
 pub struct SharedStoragePool(serde_json::Map<String, serde_json::Value>);


### PR DESCRIPTION
Fix bug introduced in recent release where the tx `receiver_id` was not set to the `delegate_action.sender_id` (according to the meta tx spec, the receiver of the txn is the sender of the signed delegate action)

fixes error like: https://nearblocks.io/txns/89XotqaBXTWYvwXsoGwu7NUCWuxQorxUXbNuf5SSodCz#execution from input 
<img width="1105" alt="Screen Shot 2024-03-27 at 7 59 41 AM" src="https://github.com/near/pagoda-relayer-rs/assets/113615218/b9a255ab-a497-4ab8-ad9e-e167d600f91d">

