### PR TITLE
replace .unwrap with map_err to return appropriate error msg for bad block_hash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relayer"
-version = "0.3.0"
+version = "0.3.3"
 edition = "2021"
 
 [dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1212,7 +1212,10 @@ async fn create_signed_meta_tx(
     if let (Some(nonce_param), Some(block_hash_param)) = (pk_and_sda.nonce, &pk_and_sda.block_hash)
     {
         nonce = nonce_param;
-        block_hash = CryptoHash::from_str(&block_hash_param.clone()).unwrap();
+        block_hash = CryptoHash::from_str(&block_hash_param.clone()).map_err(|e| RelayError {
+            status_code: StatusCode::BAD_REQUEST,
+            message: format!("block hash {:?} is invalid", block_hash_param.clone()),
+        })?;
     } else {
         (nonce, block_hash) = fetch_nonce_and_block_hash(state, signer).await?;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1212,7 +1212,7 @@ async fn create_signed_meta_tx(
     if let (Some(nonce_param), Some(block_hash_param)) = (pk_and_sda.nonce, &pk_and_sda.block_hash)
     {
         nonce = nonce_param;
-        block_hash = CryptoHash::from_str(&block_hash_param.clone()).map_err(|e| RelayError {
+        block_hash = CryptoHash::from_str(&block_hash_param.clone()).map_err(|_e| RelayError {
             status_code: StatusCode::BAD_REQUEST,
             message: format!("block hash {:?} is invalid", block_hash_param.clone()),
         })?;


### PR DESCRIPTION
previously `/sign_meta_tx` input with payload:
```
{
    "public_key": "ed25519:9Mds18aVELa6Vd9m1Vvg5jHkNNdM1p65Pg4oJNcLFBEx",
    "signed_delegate_action": {
        "delegate_action": {
            "max_block_height": 116176890,
            "nonce": 112874567000108,
            "public_key": "ed25519:Fzyhpa7ygzDM6BQdHLx8PLo7fmKQJPxKMaYggG2Y56ia",
            "receiver_id": "usdt.tether-token.near",
            "sender_id": "deddd699124e59811b63e6362ce087a699c4c567746f69c1df80df8c44e2a68f",
            "actions": [
                {
                    "FunctionCall": {
                        "method_name": "ft_transfer",
                        "args": "eyJyZWNlaXZlcl9pZCI6IjI4M2ZmZTM5NDY2YjE0NzhjYzJhODM1ZTYxN2NmZGUyYjBjNGQ4ZWZhZDNkNzkxYmQ0NDZhODI3ODkyMGI1ZDIiLCJhbW91bnQiOiIxMDAwMCJ9",
                        "gas": 30000000000000,
                        "deposit": "1"
                    }
                }
            ]
        },
        "signature": "ed25519:4gXZkdxAdWVF3xrHmy9Jrjh2b3ihjoA7UDxNtRqqqeXTfsaxyiydthn1dNZi6zk4QLEZyaK3okpxfGHxQpa42gZD"
    },
    "nonce": 113369646000521,
    "block_hash": "c4dad605b436e99d29b72e9dd56d1dc0ecb38d3b66c3bd8975fc6de96c2a7958"
}
```
would cause an internal server error due to the `.unwrap()` of the `block_hash` failing. Replacing the `.unwrap()` with `.map_err()` fixes the problem, so the new return msg is:
```
block hash "c4dad605b436e99d29b72e9dd56d1dc0ecb38d3b66c3bd8975fc6de96c2a7958" is invalid
```